### PR TITLE
make desktop controller language agnostic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -619,10 +619,10 @@ const loadContent = (appElement) => {
 
 document.addEventListener('DOMContentLoaded', async () => {
     const appElement = document.querySelector('pc-app');
+    const app = (await appElement.ready()).app;
 
     loadContent(appElement);
 
-    const app = (await appElement.ready()).app;
     const cameraElement = await document.querySelector('pc-entity[name="camera"]').ready();
     const camera = cameraElement.entity;
     const settings = migrateSettings(await window.sse?.settings);

--- a/src/input.js
+++ b/src/input.js
@@ -445,7 +445,6 @@ class DesktopController {
     }
 }
 
-
 class AppController {
     constructor() {
         this.touch = new TouchController();

--- a/src/input.js
+++ b/src/input.js
@@ -367,6 +367,7 @@ class DesktopController {
             arrowup: 'lookup',
             arrowdown: 'lookdown'
         };
+
         const mouseInput = new MouseInput();
         const leftKeys = new DampedJoystick();
         const rightKeys = new DampedJoystick();

--- a/src/input.js
+++ b/src/input.js
@@ -367,7 +367,6 @@ class DesktopController {
             arrowup: 'lookup',
             arrowdown: 'lookdown'
         };
-        
         const mouseInput = new MouseInput();
         const leftKeys = new DampedJoystick();
         const rightKeys = new DampedJoystick();

--- a/src/input.js
+++ b/src/input.js
@@ -356,18 +356,18 @@ class DesktopController {
         };
 
         const keys = {
-            w: 'forward',
-            a: 'left',
-            s: 'backward',
-            d: 'right',
-            q: 'up',
-            e: 'down',
+            keyw: 'forward',
+            keya: 'left',
+            keys: 'backward',
+            keyd: 'right',
+            keyq: 'up',
+            keye: 'down',
             arrowleft: 'lookleft',
             arrowright: 'lookright',
             arrowup: 'lookup',
             arrowdown: 'lookdown'
         };
-
+        
         const mouseInput = new MouseInput();
         const leftKeys = new DampedJoystick();
         const rightKeys = new DampedJoystick();
@@ -403,7 +403,7 @@ class DesktopController {
                 return;
             }
 
-            const key = event.key.toLowerCase();
+            const key = event.code.toLowerCase();
             if (keys.hasOwnProperty(key)) {
                 event.stopPropagation();
                 event.preventDefault();
@@ -444,6 +444,7 @@ class DesktopController {
         this.right = right;
     }
 }
+
 
 class AppController {
     constructor() {


### PR DESCRIPTION
Desktop controller only works if the current keyboard language is english. Switch to use the key code instead the ascii value to be language agnostic.