### PR TITLE
Add null checks for keyframes and AnimCamera instantiation

### DIFF
--- a/src/anim-camera.js
+++ b/src/anim-camera.js
@@ -122,6 +122,11 @@ class AnimCamera {
         const { times, values } = keyframes;
         const { position, target } = values;
 
+        // Return null if there are no keyframes or invalid data
+        if (!times?.length || !position?.length || !target?.length) {
+            return null;
+        }
+
         // construct the points array containing position and target
         const points = [];
         for (let i = 0; i < times.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,11 @@ class Viewer {
             if (animTracks?.length > 0 && camera.startAnim === 'animTrack') {
                 const track = animTracks.find(track => track.name === camera.animTrack);
                 if (track) {
-                    return AnimCamera.fromTrack(track);
+                    const animCamera = AnimCamera.fromTrack(track);
+                    // If fromTrack returns null, this branch will be skipped
+                    if (animCamera) {
+                        return animCamera;
+                    }
                 }
             } else if (isObjectExperience) {
                 // create a slowly rotating animation around it


### PR DESCRIPTION
In the case where this function is triggered when the num poses are zero, to avoid errors, im adding a validity check to avoid crashes. Eg issues like [this](https://github.com/playcanvas/supersplat/issues/454).