### PR TITLE
Fix event name typo and flag name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -534,7 +534,7 @@ const initXr = (app, cameraElement, state, events) => {
     app.xr.on('available:immersive-ar', (available) => {
         state.hasAR = available;
     });
-    app.xr.on('available:immersize-vr', (available) => {
+    app.xr.on('available:immersive-vr', (available) => {
         state.hasXR = available;
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -535,7 +535,7 @@ const initXr = (app, cameraElement, state, events) => {
         state.hasAR = available;
     });
     app.xr.on('available:immersive-vr', (available) => {
-        state.hasXR = available;
+        state.hasVR = available;
     });
 
     const parent = cameraElement.parentElement.entity;


### PR DESCRIPTION
When testing VR mode I noticed a typo in the event and flag name of one of the PRs merged recently: https://github.com/playcanvas/supersplat-viewer/pull/14/files