### PR TITLE
Load poster using img

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,11 +19,17 @@
             if (url.searchParams.has('skybox')) params.skyboxUrl = url.searchParams.get('skybox');
             if (url.searchParams.has('ministats')) params.ministats = true;
 
+            const createImage = (url) => {
+                const img = new Image();
+                img.src = url;
+                return img;
+            };
+
             window.sse = {
+                poster: params.posterUrl && createImage(params.posterUrl),
                 settings: fetch(settingsUrl).then(response => response.json()),
                 contentUrl,
                 contents: fetch(contentUrl),
-                poster: params.posterUrl && fetch(params.posterUrl).then(response => response.blob()),
                 params
             };
         </script>
@@ -211,13 +217,10 @@
             // Load the poster image if available
             const poster = window.sse?.poster;
             if (poster) {
-                poster.then((blob) => {
-                    const url = URL.createObjectURL(blob);
-                    const element = document.getElementById('poster');
-                    element.style.backgroundImage = `url(${url})`;
-                    element.style.display = 'block';
-                    element.style.filter = 'blur(40px)';
-                });
+                const element = document.getElementById('poster');
+                element.style.backgroundImage = `url(${poster.src})`;
+                element.style.display = 'block';
+                element.style.filter = 'blur(40px)';
             }
         </script>
     </body>

--- a/src/index.js
+++ b/src/index.js
@@ -497,8 +497,8 @@ class Viewer {
 
 // displays a blurry poster image which resolves to sharp during loading
 const initPoster = (events) => {
-    const blur = progress => `blur(${Math.floor((100 - progress) * 0.4)}px)`;
     const element = document.getElementById('poster');
+    const blur = progress => `blur(${Math.floor((100 - progress) * 0.4)}px)`;
 
     events.on('progress:changed', (progress) => {
         element.style.filter = blur(progress);


### PR DESCRIPTION
Using fetch to download the poster image results in CORS implications. So here we use an image element to preload the image instead.