### PR TITLE
Add loading watermark

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,13 @@ const initPoster = (events) => {
     const element = document.getElementById('poster');
     const blur = progress => `blur(${Math.floor((100 - progress) * 0.4)}px)`;
 
+    let watermark = 0;
+
     events.on('progress:changed', (progress) => {
-        element.style.filter = blur(progress);
+        if (progress > watermark) {
+            watermark = progress;
+            element.style.filter = blur(progress);
+        }
     });
 
     events.on('firstFrame', () => {


### PR DESCRIPTION
Add a watermark for progress bar because the timing of fetch requests of multiple SOGS textures can result in progress snapping forward and back, looks unsightly.