### PR TITLE
Fix Cloudflare rendering issue

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
         <base href="">
         <link rel="stylesheet" href="./index.css">
-        <script type="module">
+        <script type="module" data-cfasync="false">
             const createImage = (url) => {
                 const img = new Image();
                 img.src = url;
@@ -302,7 +302,7 @@
         </svg>
 
         <!-- Application Script -->
-        <script type="module">
+        <script type="module" data-cfasync="false">
             import { main } from './index.js';
 
             const { config, settings } = window.sse;


### PR DESCRIPTION
This PR adds `data-cfasync="false"` to the script tag.
It fixes an issue where the viewer fails to render when Cloudflare Rocket Loader is enabled.

Please check #106 (Viewer does not render when Cloudflare Rocker Loader is enabled)