### PR TITLE
Fix: Issue #732 - Viewer plays animation even when set to None

### DIFF
--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -52,7 +52,7 @@ class CameraManager {
             if (animTracks?.length > 0 && settings.startMode === 'animTrack') {
                 // use the first animTrack
                 return animTracks[0];
-            } else if (isObjectExperience) {
+            } else if (isObjectExperience && settings.startMode !== 'none') {
                 // create basic rotation animation if no anim track is specified
                 initial.calcFocusPoint(tmpv);
                 return createRotateTrack(initial.position, tmpv, initial.fov);

--- a/src/schemas/v2.ts
+++ b/src/schemas/v2.ts
@@ -78,7 +78,7 @@ type ExperienceSettings = {
     cameras: Camera[],
     annotations: Annotation[],
 
-    startMode: 'default' | 'animTrack' | 'annotation',
+    startMode: 'default' | 'animTrack' | 'annotation' | 'none',
 
     hasStartPose?: boolean
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -95,7 +95,7 @@ const migrateV2 = (v1: V1): V2 => {
             }
         }],
         annotations: [],
-        startMode: v1.camera.startAnim === 'animTrack' ? 'animTrack' : 'default',
+        startMode: v1.camera.startAnim === 'none' ? 'none' : v1.camera.startAnim === 'animTrack' ? 'animTrack' : 'default',
         hasStartPose: !!(v1.camera.position && v1.camera.target)
     };
 };


### PR DESCRIPTION
This PR fixes an issue where the viewer still started a camera animation even when **Animation = None** was selected in the Publish panel.

### Changes

* Add explicit `'none'` option to `startMode`
* Prevent default animation fallback when `startMode === 'none'`
* Fix v1 → v2 migration to preserve `startAnim: 'none'`

### Result

Viewer now correctly respects **Animation = None** and does not trigger any animation on load.

[https://github.com/playcanvas/supersplat/issues/732](https://github.com/playcanvas/supersplat/issues/732)
