### PR TITLE
fix: check fullscreen state before calling exitFullscreen

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -76,7 +76,9 @@ const initUI = (global: Global) => {
 
     const exitFullscreen = () => {
         if (hasFullscreenAPI) {
-            document.exitFullscreen();
+            if (document.fullscreenElement) {
+                document.exitFullscreen().catch(() => {});
+            }
         } else {
             window.parent.postMessage('exitFullscreen', '*');
             state.isFullscreen = false;


### PR DESCRIPTION
## Summary

- Fixes Safari error when `exitFullscreen()` is called while not in fullscreen mode
- Adds guard to check `document.fullscreenElement` before calling `document.exitFullscreen()`
- Catches potential promise rejection for extra safety

## Details

The orientation change listener calls `exitFullscreen()` when rotating from landscape to portrait, even if the user was never in fullscreen. Safari throws `TypeError: Not in fullscreen` in this case, whereas Chrome/Firefox silently ignore it.

Closes #134
