### PR TITLE
feat(dome): Adding Skydome as option for skybox

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The app supports a few useful URL parameters (though please note these are subje
 | `settings` | URL of the `settings.json` file | `./settings.json` |
 | `content` | URL of the scene file (`.ply`, `.sog`, `.meta.json`, `.lod-meta.json`) | `./scene.compressed.ply` |
 | `skybox` | URL of an equirectangular skybox image | |
+| `skyprojection` | Projection for `skybox` (`box` or `dome`) | |
+| `skydome` | Alias for `skybox` with `skyprojection=dome` | |
 | `poster` | URL of an image to show while loading | |
 | `noui` | Hide UI | |
 | `noanim` | Start with animation paused | |
@@ -101,7 +103,13 @@ type ExperienceSettings = {
         animTrack: string
     },
     background: {
-        color?: number[]
+        color?: number[],
+        skybox?: {
+            url?: string,
+            projection?: 'box' | 'dome',
+            scale?: number,
+            center?: number[]
+        }
     },
     animTracks: AnimTrack[]
 };

--- a/src/index.html
+++ b/src/index.html
@@ -17,12 +17,17 @@
 
             const posterUrl = url.searchParams.get('poster');
             const skyboxUrl = url.searchParams.get('skybox');
+            const skydomeUrl = url.searchParams.get('skydome');
+            const skyboxProjection = url.searchParams.get('skyprojection');
+            const resolvedSkyboxUrl = skyboxUrl || skydomeUrl;
+            const resolvedProjection = skyboxProjection || (skydomeUrl ? 'dome' : undefined);
             const settingsUrl = url.searchParams.has('settings') ? url.searchParams.get('settings') : './settings.json';
             const contentUrl = url.searchParams.has('content') ? url.searchParams.get('content') : './scene.compressed.ply';
 
             const sseConfig = {
                 poster: posterUrl && createImage(posterUrl),
-                skyboxUrl,
+                skyboxUrl: resolvedSkyboxUrl,
+                skyboxProjection: resolvedProjection,
                 contentUrl,
                 contents: fetch(contentUrl),
                 noui: url.searchParams.has('noui'),

--- a/src/schemas/v2.ts
+++ b/src/schemas/v2.ts
@@ -70,7 +70,12 @@ type ExperienceSettings = {
     soundUrl?: string,
     background: {
         color: [number, number, number],
-        skyboxUrl?: string
+        skybox?: {
+            url?: string,
+            projection?: 'box' | 'dome',
+            scale?: number,
+            center?: number[]
+        }
     },
     postEffectSettings: PostEffectSettings,
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ type InputMode = 'desktop' | 'touch';
 type Config = {
     poster?: HTMLImageElement;
     skyboxUrl?: string;
+    skyboxProjection?: 'box' | 'dome';
     contentUrl?: string;
     contents?: Promise<Response>;
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -280,7 +280,7 @@ class Viewer {
 
             if (skydomeRadius > 0) {
                 vec.sub2(skydomeCenter, camera.position);
-                const domeFar = vec.length() + skydomeRadius;
+                const domeFar = vec.length() + skydomeRadius*2;
                 far = Math.max(far, domeFar);
             }
 


### PR DESCRIPTION
I think it's quite useful to allow user to load skydome. It is particularly relevant when loading cleaned-up grounded objects ( example a building without it's context). 


# Summary
Unifies skybox/skydome configuration under `background.skybox`, adds dome projection support, and refreshes the example with v2 settings and a default orbit anim track.

## Changes
- Replaced `skydomeUrl` with a single `background.skybox` object (`url`, `projection`, `scale`, `center`) in the v2 schema.  
- Added `skyprojection` query param and kept `skydome` as a backwards‑compatible alias.  
- Implemented dome rendering via a `DomeGeometry` mesh (background‑only) and expanded camera far clip when a dome is present.  
- Made the dome world‑aligned (uses the configured `center`, no camera‑follow).  
- Updated `example/settings.json` to v2 and included a looping orbit anim track for a better out‑of‑box demo.  

---

You can test this PR with the example here:  https://github.com/preserve-archi/supersplat-viewer-skyDomeExample