### PR TITLE
feat(CameraInfo): Adding a panel for camera info

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -208,6 +208,10 @@
                                 <span class="control-action">Reset Camera</span>
                                 <span class="control-key">R</span>
                             </div>
+                            <div class="control-item">
+                                <span class="control-action">Toggle Camera Info</span>
+                                <span class="control-key">I</span>
+                            </div>
                         </div>
                         <div id="touchInfoPanel" class="hidden">
                             <div class="control-spacer"></div>
@@ -240,6 +244,29 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+
+            <!-- Camera Info Panel -->
+            <div id="cameraInfoPanel" class="hidden" onpointerdown="event.stopPropagation()">
+                <h1>Camera</h1>
+                <div class="control-item">
+                    <span class="control-action">Position</span>
+                    <span id="cameraPosition" class="control-key">0.00, 0.00, 0.00</span>
+                </div>
+                <div class="control-item">
+                    <span class="control-action">Target</span>
+                    <span id="cameraTarget" class="control-key">0.00, 0.00, 0.00</span>
+                </div>
+                <div class="control-item">
+                    <span class="control-action">Zoom</span>
+                    <span id="cameraZoom" class="control-key">0.00</span>
+                </div>
+                <div class="control-spacer"></div>
+                <h1>Scene</h1>
+                <div class="control-item">
+                    <span class="control-action">Splat Count</span>
+                    <span id="splatCount" class="control-key">0</span>
                 </div>
             </div>
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -395,6 +395,51 @@ button {
     }
 }
 
+/* cameraInfoPanel */
+#cameraInfoPanel {
+    position: fixed;
+    top: 16px;
+    right: max(16px, env(safe-area-inset-right));
+    min-width: 320px;
+    padding: 16px;
+    border-radius: 8px;
+
+    display: flex;
+    flex-direction: column;
+
+    font-size: 14px;
+
+    color: $clr-text;
+    background-color: rgba($clr-bkg, 0.8);
+
+    h1 {
+        font-size: 14px;
+        font-weight: bold;
+        padding: 0 0 6px 0;
+        color: $clr-text-light;
+    }
+
+    .control-item {
+        display: flex;
+        justify-content: space-between;
+        gap: 32px;
+        line-height: 1.5;
+
+        > .control-action {
+            text-align: left;
+        }
+
+        > .control-key {
+            text-align: right;
+        }
+    }
+
+    .control-spacer {
+        border-bottom: 1px dashed #666;
+        margin: 10px 0;
+    }
+}
+
 #joystickBase {
     position: absolute;
     width: 96px;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -32,6 +32,7 @@ const initUI = (global: Global) => {
         'arMode', 'vrMode',
         'enterFullscreen', 'exitFullscreen',
         'info', 'infoPanel', 'desktopTab', 'touchTab', 'desktopInfoPanel', 'touchInfoPanel',
+        'cameraInfoPanel', 'cameraPosition', 'cameraTarget', 'cameraZoom', 'splatCount',
         'timelineContainer', 'handle', 'time',
         'buttonContainer',
         'play', 'pause',
@@ -172,10 +173,15 @@ const initUI = (global: Global) => {
         dom.infoPanel.classList.add('hidden');
     });
 
+    dom.cameraInfoPanel.addEventListener('pointerdown', () => {
+        dom.cameraInfoPanel.classList.add('hidden');
+    });
+
     events.on('inputEvent', (event) => {
         if (event === 'cancel') {
             // close info panel on cancel
             dom.infoPanel.classList.add('hidden');
+            dom.cameraInfoPanel.classList.add('hidden');
             dom.settingsPanel.classList.add('hidden');
 
             // close fullscreen on cancel
@@ -184,6 +190,17 @@ const initUI = (global: Global) => {
             }
         } else if (event === 'interrupt') {
             dom.settingsPanel.classList.add('hidden');
+            dom.cameraInfoPanel.classList.add('hidden');
+        }
+    });
+
+    const toggleCameraInfo = () => {
+        dom.cameraInfoPanel.classList.toggle('hidden');
+    };
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key.toLowerCase() === 'i') {
+            toggleCameraInfo();
         }
     });
 
@@ -336,6 +353,16 @@ const initUI = (global: Global) => {
     if (config.noui) {
         dom.ui.classList.add('hidden');
     }
+
+    const formatVec = (value: number) => value.toFixed(2);
+    const formatVec3 = (x: number, y: number, z: number) => `${formatVec(x)}, ${formatVec(y)}, ${formatVec(z)}`;
+
+    events.on('cameraInfo', (position, target, zoom, splatCount) => {
+        dom.cameraPosition.textContent = formatVec3(position.x, position.y, position.z);
+        dom.cameraTarget.textContent = formatVec3(target.x, target.y, target.z);
+        dom.cameraZoom.textContent = formatVec(zoom);
+        dom.splatCount.textContent = splatCount.toString();
+    });
 
     // tooltips
     const tooltip = new Tooltip(dom.tooltip);

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -265,6 +265,9 @@ class Viewer {
             cameraEntity.camera.nearClip = near;
         };
 
+        const cameraInfoTarget = new Vec3();
+        let splatCount = 0;
+
         // handle application update
         app.on('update', (deltaTime) => {
             // in xr mode we leave the camera alone
@@ -281,6 +284,11 @@ class Viewer {
 
                 // apply to the camera entity
                 applyCamera(this.cameraManager.camera);
+
+                if (!config.noui) {
+                    this.cameraManager.camera.calcFocusPoint(cameraInfoTarget);
+                    events.fire('cameraInfo', this.cameraManager.camera.position, cameraInfoTarget, this.cameraManager.camera.distance, splatCount);
+                }
             }
         });
 
@@ -292,6 +300,7 @@ class Viewer {
         // wait for the model to load
         Promise.all([gsplatLoad, skyboxLoad]).then((results) => {
             const gsplat = results[0].gsplat as GSplatComponent;
+            splatCount = gsplat.resource?.numSplats ?? 0;
 
             // get scene bounding box
             const gsplatBbox = gsplat.customAabb;


### PR DESCRIPTION
## Summary  
Currently, it is difficult to know the current camera position and target. This PR adds a camera info panel that toggles with the **I** key to help developers read current camera position/target. 

## Changes  
- Introduced a camera info panel (position, target, zoom, splat count).  
- Added keyboard toggle (`I`) so devs can quickly capture camera values for setup.  

