### PR TITLE
Smooth camera transitions for annotations, picks, and frame/reset

### DIFF
--- a/src/cameras/orbit-controller.ts
+++ b/src/cameras/orbit-controller.ts
@@ -43,7 +43,7 @@ class OrbitController implements CameraController {
         p.position.copy(camera.position);
         p.angles.copy(camera.angles);
         p.distance = camera.distance;
-        this.controller.attach(p, true);
+        this.controller.attach(p, false);
     }
 }
 


### PR DESCRIPTION
## Summary

- Eliminate dual interpolation when animating the camera to a target pose (annotation click, scene pick, frame, reset). Previously, the orbit controller's exponential damping and the CameraManager's easeOut transition ran simultaneously, causing fast, jerky camera movement.
- The orbit controller's `goto()` now snaps instantly to the destination (`attach(pose, false)`), and a single time-based transition in CameraManager handles all animation — producing a smooth, predictable, frame-rate-independent curve.
- Transition duration increased from 0.5s to 1.0s for a more cinematic feel.
- Annotation camera FOV is now correctly interpolated during the transition.

## Details

**`orbit-controller.ts`**: `goto()` changed from `attach(p, true)` (damped) to `attach(p, false)` (instant), removing the competing interpolation layer.

**`camera-manager.ts`**: Added `startTransition()` helper that snapshots the current camera and resets the transition timer. Called from `annotation.activate`, `pick`, `frame`, and `reset` handlers — ensuring smooth animation even when the camera is already in orbit mode (where `cameraMode:changed` would not fire). `target.fov` is now explicitly set for annotation transitions so FOV is interpolated rather than snapped.

## Test plan

- [x] Click annotations — camera should animate smoothly over ~1s with ease-out to the annotation's camera pose (including FOV)
- [x] Click annotations while already in orbit mode — should still animate (no snap)
- [x] Click a second annotation mid-transition — should smoothly redirect from current position
- [x] Pick a point in the scene — smooth reorientation
- [x] Press frame/reset keys — smooth transition to framed/reset camera
- [x] Switch camera modes (e.g. anim → orbit) — transition should still work
- [x] Test at different frame rates (throttle in DevTools) — animation duration should remain consistent