### PR TITLE
Fix camera snap on mode transitions

### DIFF
--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -159,7 +159,9 @@ class CameraManager {
 
         // handle camera mode switching
         events.on('cameraMode:changed', (value, prev) => {
-            // store previous camera mode and pose
+            // snapshot the current pose before any controller mutation
+            startTransition();
+
             target.copy(this.camera);
             fromMode = prev;
 
@@ -170,8 +172,6 @@ class CameraManager {
             // enter new controller
             const newController = getController(value);
             newController.onEnter(this.camera);
-
-            startTransition();
         });
 
         // handle user scrubbing the animation timeline


### PR DESCRIPTION
## Summary

- Fix visual snap when switching camera modes (e.g. orbit → anim). `startTransition()` was called after `newController.onEnter()`, which can mutate `this.camera` (e.g. `AnimController.onEnter` snaps to the animation start pose). This caused `from.copy(this.camera)` to capture the new controller's pose rather than the previous one, making the transition start and end at the same point — appearing as an instant snap.
- Move `startTransition()` to run before any controller `onExit`/`onEnter` calls so the previous camera pose is captured correctly.

## Test plan

- [ ] Switch from orbit → animation mode — camera should smoothly transition to the animation start pose, not snap
- [ ] Switch from animation → orbit — should smoothly transition back
- [ ] Annotation clicks that trigger a mode change — should still animate smoothly