### PR TITLE
Add inverted voxel rendering and fix Chrome WebGPU frame pacing on macOS

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -38,6 +38,23 @@ canvas {
     height: 100%;
 }
 
+// Workaround for Chrome on macOS: without backdrop-filter on an overlaying
+// element, Chrome uses a compositor path that causes severe WebGPU frame
+// pacing issues on high-refresh-rate displays.
+//
+// This workaround can be removed once Chrome has fixed
+// https://issues.chromium.org/issues/502668704
+body::after {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 1px;
+    height: 1px;
+    backdrop-filter: blur(1px);
+    pointer-events: none;
+}
+
 button {
     appearance: none;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -52,6 +52,7 @@ body::after {
     width: 1px;
     height: 1px;
     backdrop-filter: blur(1px);
+    -webkit-backdrop-filter: blur(1px);
     pointer-events: none;
 }
 

--- a/src/voxel-debug-overlay.ts
+++ b/src/voxel-debug-overlay.ts
@@ -64,7 +64,7 @@ struct Uniforms {
     treeDepth: u32,
     projScaleY: f32,
     displayMode: u32,
-    pad2: u32
+    inverted: u32
 };
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -74,9 +74,9 @@ struct Uniforms {
 
 // ---- helpers ----
 
-// Traverse the octree for block (bx, by, bz). Returns vec2u(result, emptyLevel):
+// Traverse the octree for block (bx, by, bz). Returns vec2u(result, skipLevel):
 //   result: 0 = empty, 1 = solid, 2+ = mixed leaf (2 + leafDataIndex)
-//   emptyLevel: octree level at which emptiness was detected (only meaningful when result == 0)
+//   skipLevel: octree level for multi-block skipping (meaningful when result == 0 or 1)
 fn queryBlock(bx: i32, by: i32, bz: i32) -> vec2u {
     let depth = uniforms.treeDepth;
     var nodeIndex: u32 = 0u;
@@ -84,9 +84,9 @@ fn queryBlock(bx: i32, by: i32, bz: i32) -> vec2u {
     for (var level: u32 = depth - 1u; ; ) {
         let node = nodes[nodeIndex];
 
-        // Solid leaf sentinel
+        // Solid leaf sentinel -- return level + 1 so the caller can skip 2^(level+1) blocks
         if (node == SOLID_LEAF_MARKER) {
-            return vec2u(1u, 0u);
+            return vec2u(1u, level + 1u);
         }
 
         let childMask = (node >> 24u) & 0xFFu;
@@ -283,6 +283,7 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
     var tMaxY = (nextBoundY - ro.y) / rd.y;
     var tMaxZ = (nextBoundZ - ro.z) / rd.z;
 
+    let inv = uniforms.inverted != 0u;
     var totalWork: u32 = 0u;
 
     for (var step: u32 = 0u; step < MAX_STEPS; step++) {
@@ -290,11 +291,17 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
 
         let qResult = queryBlock(bx, by, bz);
         let blockResult = qResult.x;
-        let emptyLevel = qResult.y;
+        let skipLevel = qResult.y;
 
-        if (blockResult == 0u && emptyLevel >= 1u) {
-            // Large empty region: advance the block DDA past the empty cell
-            let cellBlocks = i32(1u << emptyLevel);
+        // Normal: skip large empty regions.  Inverted: skip large solid regions.
+        let shouldSkip = select(
+            blockResult == 0u && skipLevel >= 1u,
+            blockResult == 1u && skipLevel >= 1u,
+            inv
+        );
+
+        if (shouldSkip) {
+            let cellBlocks = i32(1u << skipLevel);
             let cellMask = ~(cellBlocks - 1);
             let cellXMin = bx & cellMask;
             let cellYMin = by & cellMask;
@@ -318,7 +325,11 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
                 }
             }
         } else {
-            if (blockResult != 0u) {
+            // Normal: enter voxel DDA for non-empty blocks.
+            // Inverted: enter voxel DDA for non-solid blocks (empty or mixed).
+            let enterDDA = select(blockResult != 0u, blockResult != 1u, inv);
+
+            if (enterDDA) {
                 let blockOrigin = gridMin + vec3f(f32(bx), f32(by), f32(bz)) * blockRes;
 
                 let blockMax = blockOrigin + vec3f(blockRes);
@@ -369,12 +380,15 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
                         );
                     }
 
-                    if (isSolid) {
+                    let isHit = select(isSolid, !isSolid, inv);
+
+                    if (isHit) {
                         if (uniforms.displayMode == 0u) {
                             let voxMin = blockOrigin + vec3f(f32(vx), f32(vy), f32(vz)) * voxelRes;
                             let vHit = intersectAABB(ro, invDir, voxMin, voxMin + vec3f(voxelRes));
                             let hitPos = ro + rd * max(vHit.x, 0.0);
-                            let result = shadeVoxelHit(hitPos, voxMin, voxelRes, ro, blockResult == 1u);
+                            let fullBlock = select(blockResult == 1u, blockResult == 0u, inv);
+                            let result = shadeVoxelHit(hitPos, voxMin, voxelRes, ro, fullBlock);
                             textureStore(outputTexture, vec2i(px, py), result);
                         } else {
                             let effort = f32(totalWork) / 256.0;
@@ -514,7 +528,7 @@ class VoxelDebugOverlay {
                     new UniformFormat('treeDepth', UNIFORMTYPE_UINT),
                     new UniformFormat('projScaleY', UNIFORMTYPE_FLOAT),
                     new UniformFormat('displayMode', UNIFORMTYPE_UINT),
-                    new UniformFormat('pad2', UNIFORMTYPE_UINT)
+                    new UniformFormat('inverted', UNIFORMTYPE_UINT)
                 ])
             },
             computeBindGroupFormat: new BindGroupFormat(device, [
@@ -647,7 +661,18 @@ class VoxelDebugOverlay {
         compute.setParameter('treeDepth', collision.treeDepth);
         compute.setParameter('projScaleY', cam.projectionMatrix.data[5]);
         compute.setParameter('displayMode', this.mode === 'heatmap' ? 1 : 0);
-        compute.setParameter('pad2', 0);
+
+        const camPos = camera.getPosition();
+        let wx = camPos.x, wy = camPos.y;
+        const wz = camPos.z;
+        if (collision.flipXY) {
+            wx = -wx;
+            wy = -wy;
+        }
+        const ix = Math.floor((wx - collision.gridMinX) / collision.voxelResolution);
+        const iy = Math.floor((wy - collision.gridMinY) / collision.voxelResolution);
+        const iz = Math.floor((wz - collision.gridMinZ) / collision.voxelResolution);
+        compute.setParameter('inverted', collision.isVoxelSolid(ix, iy, iz) ? 1 : 0);
 
         // Set storage buffers and output texture
         compute.setParameter('nodes', this.nodesBuffer);

--- a/src/voxel-debug-overlay.ts
+++ b/src/voxel-debug-overlay.ts
@@ -157,7 +157,7 @@ fn edgeFactor(hitPos: vec3f, voxMin: vec3f, voxSize: f32, edgeWidth: f32) -> f32
 }
 
 // Shade a voxel hit, returning premultiplied RGBA
-fn shadeVoxelHit(hitPos: vec3f, voxMin: vec3f, voxelRes: f32, ro: vec3f, isSolid: bool) -> vec4f {
+fn shadeVoxelHit(hitPos: vec3f, voxMin: vec3f, voxelRes: f32, ro: vec3f, isFullBlock: bool) -> vec4f {
     let dist = length(hitPos - ro);
     let pixelWorld = 2.0 * dist / (f32(uniforms.screenHeight) * uniforms.projScaleY);
     let ew = clamp(EDGE_PIXELS * pixelWorld / voxelRes, 0.01, 0.5);
@@ -178,7 +178,7 @@ fn shadeVoxelHit(hitPos: vec3f, voxMin: vec3f, voxelRes: f32, ro: vec3f, isSolid
     }
 
     var baseColor: vec3f;
-    if (isSolid) {
+    if (isFullBlock) {
         if (faceAxis == 0u) { baseColor = vec3f(1.0, 0.25, 0.2); }
         else if (faceAxis == 1u) { baseColor = vec3f(0.8, 0.15, 0.1); }
         else { baseColor = vec3f(0.55, 0.08, 0.05); }
@@ -387,8 +387,8 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
                             let voxMin = blockOrigin + vec3f(f32(vx), f32(vy), f32(vz)) * voxelRes;
                             let vHit = intersectAABB(ro, invDir, voxMin, voxMin + vec3f(voxelRes));
                             let hitPos = ro + rd * max(vHit.x, 0.0);
-                            let fullBlock = select(blockResult == 1u, blockResult == 0u, inv);
-                            let result = shadeVoxelHit(hitPos, voxMin, voxelRes, ro, fullBlock);
+                            let isFullBlock = select(blockResult == 1u, blockResult == 0u, inv);
+                            let result = shadeVoxelHit(hitPos, voxMin, voxelRes, ro, isFullBlock);
                             textureStore(outputTexture, vec2i(px, py), result);
                         } else {
                             let effort = f32(totalWork) / 256.0;
@@ -432,14 +432,6 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
             bx >= numBlocksX || by >= numBlocksY || bz >= numBlocksZ) {
             break;
         }
-    }
-
-    if (uniforms.displayMode == 0u) {
-        textureStore(outputTexture, vec2i(px, py), vec4f(0.0));
-    } else {
-        let effort = f32(totalWork) / 256.0;
-        let color = heatmap(effort);
-        textureStore(outputTexture, vec2i(px, py), vec4f(color, 1.0));
     }
 }
 `;

--- a/src/voxel-debug-overlay.ts
+++ b/src/voxel-debug-overlay.ts
@@ -433,6 +433,8 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
             break;
         }
     }
+
+    textureStore(outputTexture, vec2i(px, py), vec4f(0.0));
 }
 `;
 


### PR DESCRIPTION
## Summary

- **Chrome WebGPU frame pacing workaround**: Add a minimal `backdrop-filter` pseudo-element on `body` to force Chrome on macOS into a compositor path that avoids severe frame pacing issues on high-refresh-rate displays. Linked to [Chrome issue #502668704](https://issues.chromium.org/issues/502668704).
- **Inverted voxel debug overlay**: The voxel raymarcher now supports an inverted rendering mode that displays empty space instead of solid geometry. This activates automatically when the camera is inside a solid voxel, allowing the user to see surrounding cavities and passages from within solid regions.
- **Solid region skip optimization**: Octree traversal now returns a skip level for solid leaf nodes (not just empty ones), enabling multi-block DDA advancement through large solid regions in inverted mode — matching the existing empty-region skip optimization.

## Details

### Chrome frame pacing fix (`index.scss`)
A 1x1px `body::after` element with `backdrop-filter: blur(1px)` works around a Chrome compositing bug that causes stuttery WebGPU rendering on macOS high-refresh-rate displays. The element is invisible and non-interactive.

### Inverted voxel rendering (`voxel-debug-overlay.ts`)
- Added an `inverted` uniform (replacing the unused `pad2` padding) that flips hit/skip logic throughout the raymarcher.
- At dispatch time, the camera's voxel position is sampled via `collision.isVoxelSolid()` to auto-detect whether inverted mode should be enabled.
- Renamed `emptyLevel` → `skipLevel` to reflect that the octree query now reports skip levels for both empty and solid nodes.
- The `SOLID_LEAF_MARKER` branch now returns `level + 1` so callers can skip `2^(level+1)` blocks through solid regions.

## Test plan
- [ ] Verify smooth frame pacing in Chrome on a macOS high-refresh-rate display with WebGPU
- [ ] Confirm voxel debug overlay renders correctly in normal mode (camera outside solid geometry)
- [ ] Move camera inside solid geometry and verify the overlay automatically switches to inverted rendering showing internal cavities
- [ ] Test on a non-Chrome browser to ensure the `backdrop-filter` workaround is harmless
