### PR TITLE
Use engine Picker for compute, revert to expected-depth for raster

### DIFF
--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,11 +1,258 @@
 import {
     type AppBase,
     type Entity,
-    Picker as EnginePicker,
-    Vec3
+    type GSplatComponent,
+    type MeshInstance,
+    ADDRESS_CLAMP_TO_EDGE,
+    BLENDEQUATION_ADD,
+    BLENDMODE_ZERO,
+    BLENDMODE_ONE,
+    BLENDMODE_ONE_MINUS_SRC_ALPHA,
+    FILTER_NEAREST,
+    GSPLAT_RENDERER_COMPUTE,
+    PIXELFORMAT_RGBA8,
+    PIXELFORMAT_RGBA16F,
+    PROJECTION_ORTHOGRAPHIC,
+    Color,
+    Mat4,
+    RenderPassPicker,
+    RenderTarget,
+    ShaderChunks,
+    Texture,
+    Vec3,
+    Vec4,
+    BlendState
 } from 'playcanvas';
 
-const pickerScale = 0.25;
+// Override global picking to pack alpha-weighted splat depth instead of meshInstance id.
+const pickDepthGlsl = /* glsl */ `
+vec4 encodePickOutput(uint id) {
+    const vec4 inv = vec4(1.0 / 255.0);
+    const uvec4 shifts = uvec4(16, 8, 0, 24);
+    uvec4 col = (uvec4(id) >> shifts) & uvec4(0xff);
+    return vec4(col) * inv;
+}
+
+#ifdef GSPLAT_PICK_DEPTH
+    #ifndef CAMERAPLANES
+        #define CAMERAPLANES
+        uniform vec4 camera_params; // x: 1/far, y: far, z: near, w: isOrtho
+    #endif
+
+    vec4 getPickOutput() {
+        float normalizedDepth;
+        if (camera_params.w > 0.5) {
+            normalizedDepth = gl_FragCoord.z;
+        } else {
+            float linearDepth = 1.0 / gl_FragCoord.w;
+            normalizedDepth = (linearDepth - camera_params.z) / (camera_params.y - camera_params.z);
+        }
+
+        return vec4(gaussianColor.a * normalizedDepth, 0.0, 0.0, gaussianColor.a);
+    }
+#else
+    #ifndef PICK_CUSTOM_ID
+        uniform uint meshInstanceId;
+
+        vec4 getPickOutput() {
+            return encodePickOutput(meshInstanceId);
+        }
+    #endif
+#endif
+
+#ifdef DEPTH_PICK_PASS
+    #include "floatAsUintPS"
+    #ifndef CAMERAPLANES
+        #define CAMERAPLANES
+        uniform vec4 camera_params; // x: 1/far, y: far, z: near, w: isOrtho
+    #endif
+
+    vec4 getPickDepth() {
+        float linearDepth;
+        if (camera_params.w > 0.5) {
+            linearDepth = gl_FragCoord.z;
+        } else {
+            float viewDist = 1.0 / gl_FragCoord.w;
+            linearDepth = (viewDist - camera_params.z) / (camera_params.y - camera_params.z);
+        }
+        return float2uint(linearDepth);
+    }
+#endif
+`;
+
+const pickDepthWgsl = /* wgsl */ `
+fn encodePickOutput(id: u32) -> vec4f {
+    let inv: vec4f = vec4f(1.0 / 255.0);
+    let shifts: vec4u = vec4u(16u, 8u, 0u, 24u);
+    let col: vec4u = (vec4u(id) >> shifts) & vec4u(0xffu);
+    return vec4f(col) * inv;
+}
+
+#ifdef GSPLAT_PICK_DEPTH
+    #ifndef CAMERAPLANES
+        #define CAMERAPLANES
+        uniform camera_params: vec4f; // x: 1/far, y: far, z: near, w: isOrtho
+    #endif
+
+    fn getPickOutput() -> vec4f {
+        var normalizedDepth: f32;
+        if (uniform.camera_params.w > 0.5) {
+            normalizedDepth = pcPosition.z;
+        } else {
+            let linearDepth = 1.0 / pcPosition.w;
+            normalizedDepth = (linearDepth - uniform.camera_params.z) / (uniform.camera_params.y - uniform.camera_params.z);
+        }
+
+        let a = f32(gaussianColor.a);
+        return vec4f(a * normalizedDepth, 0.0, 0.0, a);
+    }
+#else
+    #ifndef PICK_CUSTOM_ID
+        uniform meshInstanceId: u32;
+
+        fn getPickOutput() -> vec4f {
+            return encodePickOutput(uniform.meshInstanceId);
+        }
+    #endif
+#endif
+
+#ifdef DEPTH_PICK_PASS
+    #include "floatAsUintPS"
+    #ifndef CAMERAPLANES
+        #define CAMERAPLANES
+        uniform camera_params: vec4f; // x: 1/far, y: far, z: near, w: isOrtho
+    #endif
+
+    fn getPickDepth() -> vec4f {
+        var linearDepth: f32;
+        if (uniform.camera_params.w > 0.5) {
+            linearDepth = pcPosition.z;
+        } else {
+            let viewDist = 1.0 / pcPosition.w;
+            linearDepth = (viewDist - uniform.camera_params.z) / (uniform.camera_params.y - uniform.camera_params.z);
+        }
+        return float2uint(linearDepth);
+    }
+#endif
+`;
+
+const patchGsplatPickGlsl = (chunk: string) => {
+    return chunk
+    .replace(
+        /#ifdef PICK_PASS\s*#include "pickPS"\s*#endif/,
+        '#ifdef PICK_PASS\n\t#define GSPLAT_PICK_DEPTH\n\t#include "pickPS"\n#endif'
+    )
+    .replace(
+        'pcFragColor0 = encodePickOutput(vPickId);',
+        'pcFragColor0 = getPickOutput();'
+    );
+};
+
+const patchGsplatPickWgsl = (chunk: string) => {
+    return chunk
+    .replace(
+        /#ifdef PICK_PASS\s*#include "pickPS"\s*#endif/,
+        '#ifdef PICK_PASS\n\t#define GSPLAT_PICK_DEPTH\n\t#include "pickPS"\n#endif'
+    )
+    .replace(
+        'output.color = encodePickOutput(vPickId);',
+        'output.color = getPickOutput();'
+    );
+};
+
+const patchedDevices = new WeakSet<object>();
+const vec4 = new Vec4();
+const viewProjMat = new Mat4();
+const clearColor = new Color(0, 0, 0, 1);
+const whiteColor = Color.WHITE;
+
+// Shared buffers for pixel decoding.
+const float32 = new Float32Array(1);
+const int32 = new Int32Array(float32.buffer);
+const uint32 = new Uint32Array(float32.buffer);
+
+// Convert 16-bit half-float to 32-bit float using bit manipulation.
+const half2Float = (h: number): number => {
+    const sign = (h & 0x8000) << 16;
+    const exponent = (h & 0x7C00) >> 10;
+    const mantissa = h & 0x03FF;
+
+    if (exponent === 0) {
+        if (mantissa === 0) {
+            uint32[0] = sign;
+        } else {
+            let e = -1;
+            let m = mantissa;
+            do {
+                e++;
+                m <<= 1;
+            } while ((m & 0x0400) === 0);
+            uint32[0] = sign | ((127 - 15 - e) << 23) | ((m & 0x03FF) << 13);
+        }
+    } else if (exponent === 31) {
+        uint32[0] = sign | 0x7F800000 | (mantissa << 13);
+    } else {
+        uint32[0] = sign | ((exponent + 127 - 15) << 23) | (mantissa << 13);
+    }
+
+    return float32[0];
+};
+
+const patchPickChunks = (app: AppBase) => {
+    const device = app.graphicsDevice;
+    if (patchedDevices.has(device)) {
+        return;
+    }
+
+    const glslChunks = ShaderChunks.get(device, 'glsl');
+    const wgslChunks = ShaderChunks.get(device, 'wgsl');
+
+    glslChunks.set('pickPS', pickDepthGlsl);
+    wgslChunks.set('pickPS', pickDepthWgsl);
+
+    glslChunks.set('gsplatPS', patchGsplatPickGlsl(glslChunks.get('gsplatPS')));
+    wgslChunks.set('gsplatPS', patchGsplatPickWgsl(wgslChunks.get('gsplatPS')));
+
+    patchedDevices.add(device);
+};
+
+const getWorldPoint = (camera: Entity, x: number, y: number, width: number, height: number, normalizedDepth: number) => {
+    if (!Number.isFinite(normalizedDepth) || normalizedDepth < 0 || normalizedDepth > 1) {
+        return null;
+    }
+
+    const cam = camera.camera;
+    const near = cam.nearClip;
+    const far = cam.farClip;
+    const ndcDepth = cam.projection === PROJECTION_ORTHOGRAPHIC ?
+        normalizedDepth :
+        far * normalizedDepth / (normalizedDepth * (far - near) + near);
+
+    viewProjMat.mul2(cam.projectionMatrix, cam.viewMatrix).invert();
+    vec4.set(x / width * 2 - 1, (1 - y / height) * 2 - 1, ndcDepth * 2 - 1, 1);
+    viewProjMat.transformVec4(vec4, vec4);
+    if (!Number.isFinite(vec4.w) || Math.abs(vec4.w) < 1e-8) {
+        return null;
+    }
+
+    vec4.mulScalar(1 / vec4.w);
+    if (!Number.isFinite(vec4.x) || !Number.isFinite(vec4.y) || !Number.isFinite(vec4.z)) {
+        return null;
+    }
+
+    return new Vec3(vec4.x, vec4.y, vec4.z);
+};
+
+const decodeDepth = (pixels: Uint8Array): number | null => {
+    const intBits = pixels[0] << 24 | pixels[1] << 16 | pixels[2] << 8 | pixels[3];
+    if (intBits === 0xFFFFFFFF) {
+        return null;
+    }
+
+    int32[0] = intBits;
+    const depth = float32[0];
+    return Number.isFinite(depth) ? depth : null;
+};
 
 class Picker {
     pick: (x: number, y: number) => Promise<Vec3 | null>;
@@ -13,44 +260,163 @@ class Picker {
     release: () => void;
 
     constructor(app: AppBase, camera: Entity) {
-        const picker = new EnginePicker(app, 1, 1, true);
+        const { graphicsDevice } = app;
+        patchPickChunks(app);
+
+        let colorBuffer: Texture;
+        let renderTarget: RenderTarget;
+        let renderPass: RenderPassPicker;
+
+        let depthColorBuffer: Texture;
+        let depthBuffer: Texture;
+        let depthRenderTarget: RenderTarget;
+        let depthReadRenderTarget: RenderTarget;
+        let depthRenderPass: RenderPassPicker;
+
+        const emptyMap = new Map<number, MeshInstance | GSplatComponent>();
+
+        const initDepthAccumulation = (width: number, height: number) => {
+            colorBuffer = new Texture(graphicsDevice, {
+                format: PIXELFORMAT_RGBA16F,
+                width,
+                height,
+                mipmaps: false,
+                minFilter: FILTER_NEAREST,
+                magFilter: FILTER_NEAREST,
+                addressU: ADDRESS_CLAMP_TO_EDGE,
+                addressV: ADDRESS_CLAMP_TO_EDGE,
+                name: 'picker'
+            });
+
+            renderTarget = new RenderTarget({
+                colorBuffer,
+                depth: false // not needed - gaussians are rendered back to front
+            });
+
+            renderPass = new RenderPassPicker(graphicsDevice, app.renderer);
+            // RGB: additive depth accumulation. Alpha: multiplicative transmittance.
+            renderPass.blendState = new BlendState(
+                true,
+                BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA,
+                BLENDEQUATION_ADD, BLENDMODE_ZERO, BLENDMODE_ONE_MINUS_SRC_ALPHA
+            );
+        };
+
+        const initDepthPick = (width: number, height: number) => {
+            depthColorBuffer = Texture.createDataTexture2D(graphicsDevice, 'pick', width, height, PIXELFORMAT_RGBA8);
+            depthBuffer = Texture.createDataTexture2D(graphicsDevice, 'pick-depth', width, height, PIXELFORMAT_RGBA8);
+
+            depthRenderTarget = new RenderTarget({
+                colorBuffers: [depthColorBuffer, depthBuffer],
+                depth: true
+            });
+
+            depthReadRenderTarget = new RenderTarget({
+                colorBuffer: depthBuffer,
+                depth: false
+            });
+
+            depthRenderPass = new RenderPassPicker(graphicsDevice, app.renderer);
+        };
+
+        const readTexture = <T extends Uint8Array | Uint16Array>(
+            texture: Texture,
+            x: number,
+            y: number,
+            renderTarget: RenderTarget
+        ): Promise<T> => {
+            const texY = graphicsDevice.isWebGL2 ? renderTarget.height - y - 1 : y;
+
+            return texture.read(x, texY, 1, 1, {
+                renderTarget,
+                immediate: true
+            }) as Promise<T>;
+        };
 
         this.pick = async (x: number, y: number) => {
-            const width = Math.ceil(app.graphicsDevice.width * pickerScale);
-            const height = Math.ceil(app.graphicsDevice.height * pickerScale);
+            const width = Math.floor(graphicsDevice.width);
+            const height = Math.floor(graphicsDevice.height);
 
             // bail out if the device hasn't been sized yet
             if (width <= 0 || height <= 0) {
                 return null;
             }
 
-            // clamp normalized inputs and convert to integer pixel coordinates
-            // in [0, width-1] / [0, height-1] so an exact 1.0 doesn't fall off the texture.
-            const px = Math.min(width - 1, Math.max(0, Math.floor(x * width)));
-            const py = Math.min(height - 1, Math.max(0, Math.floor(y * height)));
+            const screenX = Math.min(width - 1, Math.max(0, Math.floor(x * width)));
+            const screenY = Math.min(height - 1, Math.max(0, Math.floor(y * height)));
+            const worldLayer = app.scene.layers.getLayerByName('World');
+            if (!worldLayer) {
+                return null;
+            }
 
-            // enable gsplat IDs only for the duration of the pick so we don't pay the
-            // memory/perf cost between picks (picker instances are typically long-lived).
             const prevEnableIds = app.scene.gsplat.enableIds;
             app.scene.gsplat.enableIds = true;
 
-            picker.resize(width, height);
+            let normalizedDepth: number | null = null;
 
-            const worldLayer = app.scene.layers.getLayerByName('World');
-            picker.prepare(camera.camera, app.scene, [worldLayer]);
+            try {
+                if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
+                    if (!depthRenderPass) {
+                        initDepthPick(width, height);
+                    } else {
+                        depthRenderTarget.resize(width, height);
+                        depthReadRenderTarget.resize(width, height);
+                    }
 
-            const result = await picker.getWorldPointAsync(px, py);
+                    depthRenderPass.init(depthRenderTarget);
+                    depthRenderPass.setClearColor(whiteColor);
+                    depthRenderPass.depthStencilOps.clearDepth = true;
+                    depthRenderPass.update(camera.camera, app.scene, [worldLayer], emptyMap, true);
+                    depthRenderPass.render();
 
-            // pick is only invoked from user dblclick events, so concurrent invocations
-            // (which would race on enableIds) aren't a concern in practice.
-            // eslint-disable-next-line require-atomic-updates
-            app.scene.gsplat.enableIds = prevEnableIds;
+                    const pixels = await readTexture<Uint8Array>(depthBuffer, screenX, screenY, depthReadRenderTarget);
+                    normalizedDepth = decodeDepth(pixels);
+                } else {
+                    if (!renderPass) {
+                        initDepthAccumulation(width, height);
+                    } else {
+                        renderTarget.resize(width, height);
+                    }
 
-            return result;
+                    renderPass.init(renderTarget);
+                    renderPass.setClearColor(clearColor);
+                    renderPass.update(camera.camera, app.scene, [worldLayer], emptyMap, false);
+                    renderPass.render();
+
+                    const pixels = await readTexture<Uint16Array>(colorBuffer, screenX, screenY, renderTarget);
+
+                    const r = half2Float(pixels[0]);
+                    const transmittance = half2Float(pixels[3]);
+                    const alpha = 1 - transmittance;
+
+                    if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
+                        normalizedDepth = null;
+                    } else {
+                        normalizedDepth = r / alpha;
+                    }
+                }
+            } finally {
+                // Pick is invoked from user dblclick events, so concurrent invocations
+                // racing on enableIds are not expected in practice.
+                // eslint-disable-next-line require-atomic-updates
+                app.scene.gsplat.enableIds = prevEnableIds;
+            }
+
+            if (normalizedDepth === null) {
+                return null;
+            }
+
+            return getWorldPoint(camera, screenX, screenY, width, height, normalizedDepth);
         };
 
         this.release = () => {
-            picker.destroy();
+            renderPass?.destroy();
+            renderTarget?.destroy();
+            colorBuffer?.destroy();
+            depthRenderPass?.destroy();
+            depthRenderTarget?.destroyTextureBuffers();
+            depthRenderTarget?.destroy();
+            depthReadRenderTarget?.destroy();
         };
     }
 }

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -242,20 +242,28 @@ const registerPickerShaderPatches = (app: AppBase) => {
     const glslChunks = ShaderChunks.get(device, 'glsl');
     const wgslChunks = ShaderChunks.get(device, 'wgsl');
 
+    const glslPickPS = glslChunks.get('pickPS');
+    const glslGsplatPS = glslChunks.get('gsplatPS');
+    const wgslPickPS = wgslChunks.get('pickPS');
+    const wgslGsplatPS = wgslChunks.get('gsplatPS');
+
+    // Patch strings before mutating ShaderChunks so engine mismatches leave globals untouched.
+    const patchedGlslGsplatPS = patchGsplatPickGlsl(glslGsplatPS);
+    const patchedWgslGsplatPS = patchGsplatPickWgsl(wgslGsplatPS);
+
     const state: PickerShaderPatchState = {
-        glslPickPS: glslChunks.get('pickPS'),
-        glslGsplatPS: glslChunks.get('gsplatPS'),
-        wgslPickPS: wgslChunks.get('pickPS'),
-        wgslGsplatPS: wgslChunks.get('gsplatPS'),
+        glslPickPS,
+        glslGsplatPS,
+        wgslPickPS,
+        wgslGsplatPS,
         refCount: 1
     };
     pickerShaderPatchState.set(device, state);
 
     glslChunks.set('pickPS', pickDepthGlsl);
     wgslChunks.set('pickPS', pickDepthWgsl);
-
-    glslChunks.set('gsplatPS', patchGsplatPickGlsl(state.glslGsplatPS));
-    wgslChunks.set('gsplatPS', patchGsplatPickWgsl(state.wgslGsplatPS));
+    glslChunks.set('gsplatPS', patchedGlslGsplatPS);
+    wgslChunks.set('gsplatPS', patchedWgslGsplatPS);
 };
 
 const unregisterPickerShaderPatches = (app: AppBase) => {
@@ -312,7 +320,6 @@ class Picker {
 
     constructor(app: AppBase, camera: Entity) {
         const { graphicsDevice } = app;
-        registerPickerShaderPatches(app);
 
         let enginePicker: EnginePicker | undefined;
         let accumBuffer: Texture;
@@ -388,6 +395,8 @@ class Picker {
                     enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
                     return await enginePicker.getWorldPointAsync(screenX, screenY);
                 }
+
+                registerPickerShaderPatches(app);
 
                 if (!accumPass) {
                     initRasterAccum(width, height);

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,3 +1,13 @@
+/**
+ * Double-click world picking for splat scenes.
+ *
+ * - **Compute renderer (WebGPU tiled-compute)**: uses engine `Picker` with depth enabled — expected
+ *   depth is already provided by the tile-composite path.
+ * - **Raster renderers (WebGL, CPU / GPU sort, etc.)**: custom `pickPS` / `gsplatPS` patch plus
+ *   `RGBA16F` alpha-weighted depth accumulation, because the stock pick pass encodes splat IDs /
+ *   last-fragment depth rather than expected depth.
+ */
+
 import {
     type AppBase,
     type Entity,
@@ -10,9 +20,9 @@ import {
     BLENDMODE_ONE_MINUS_SRC_ALPHA,
     FILTER_NEAREST,
     GSPLAT_RENDERER_COMPUTE,
-    PIXELFORMAT_RGBA8,
     PIXELFORMAT_RGBA16F,
     PROJECTION_ORTHOGRAPHIC,
+    Picker as EnginePicker,
     Color,
     Mat4,
     RenderPassPicker,
@@ -136,39 +146,62 @@ fn encodePickOutput(id: u32) -> vec4f {
 #endif
 `;
 
+const pickPassChunkInjected = [
+    '#ifdef PICK_PASS',
+    '    #define GSPLAT_PICK_DEPTH',
+    '    #include "pickPS"',
+    '#endif'
+].join('\n');
+
+const safeChunkReplace = (s: string, find: string | RegExp, repl: string) => {
+    const out = s.replace(find, repl);
+    if (out === s) {
+        throw new Error('picker: engine gsplat/pick chunk patch failed (engine version mismatch?)');
+    }
+    return out;
+};
+
 const patchGsplatPickGlsl = (chunk: string) => {
-    return chunk
-    .replace(
-        /#ifdef PICK_PASS\s*#include "pickPS"\s*#endif/,
-        '#ifdef PICK_PASS\n\t#define GSPLAT_PICK_DEPTH\n\t#include "pickPS"\n#endif'
-    )
-    .replace(
+    return safeChunkReplace(
+        safeChunkReplace(
+            chunk,
+            /#ifdef PICK_PASS\s*#include "pickPS"\s*#endif/,
+            pickPassChunkInjected
+        ),
         'pcFragColor0 = encodePickOutput(vPickId);',
         'pcFragColor0 = getPickOutput();'
     );
 };
 
 const patchGsplatPickWgsl = (chunk: string) => {
-    return chunk
-    .replace(
-        /#ifdef PICK_PASS\s*#include "pickPS"\s*#endif/,
-        '#ifdef PICK_PASS\n\t#define GSPLAT_PICK_DEPTH\n\t#include "pickPS"\n#endif'
-    )
-    .replace(
+    return safeChunkReplace(
+        safeChunkReplace(
+            chunk,
+            /#ifdef PICK_PASS\s*#include "pickPS"\s*#endif/,
+            pickPassChunkInjected
+        ),
         'output.color = encodePickOutput(vPickId);',
         'output.color = getPickOutput();'
     );
 };
 
-const patchedDevices = new WeakSet<object>();
+type PickerShaderPatchState = {
+    glslPickPS: string;
+    glslGsplatPS: string;
+    wgslPickPS: string;
+    wgslGsplatPS: string;
+    refCount: number;
+};
+
+/** Per-device original chunk strings + refcount so we can restore after the last Picker releases. */
+const pickerShaderPatchState = new WeakMap<object, PickerShaderPatchState>();
+
 const vec4 = new Vec4();
 const viewProjMat = new Mat4();
 const clearColor = new Color(0, 0, 0, 1);
-const whiteColor = Color.WHITE;
 
-// Shared buffers for pixel decoding.
+// Shared buffer for half-to-float conversion
 const float32 = new Float32Array(1);
-const int32 = new Int32Array(float32.buffer);
 const uint32 = new Uint32Array(float32.buffer);
 
 // Convert 16-bit half-float to 32-bit float using bit manipulation.
@@ -198,22 +231,51 @@ const half2Float = (h: number): number => {
     return float32[0];
 };
 
-const patchPickChunks = (app: AppBase) => {
+const registerPickerShaderPatches = (app: AppBase) => {
     const device = app.graphicsDevice;
-    if (patchedDevices.has(device)) {
+    const existing = pickerShaderPatchState.get(device);
+    if (existing) {
+        existing.refCount++;
         return;
     }
 
     const glslChunks = ShaderChunks.get(device, 'glsl');
     const wgslChunks = ShaderChunks.get(device, 'wgsl');
 
+    const state: PickerShaderPatchState = {
+        glslPickPS: glslChunks.get('pickPS'),
+        glslGsplatPS: glslChunks.get('gsplatPS'),
+        wgslPickPS: wgslChunks.get('pickPS'),
+        wgslGsplatPS: wgslChunks.get('gsplatPS'),
+        refCount: 1
+    };
+    pickerShaderPatchState.set(device, state);
+
     glslChunks.set('pickPS', pickDepthGlsl);
     wgslChunks.set('pickPS', pickDepthWgsl);
 
-    glslChunks.set('gsplatPS', patchGsplatPickGlsl(glslChunks.get('gsplatPS')));
-    wgslChunks.set('gsplatPS', patchGsplatPickWgsl(wgslChunks.get('gsplatPS')));
+    glslChunks.set('gsplatPS', patchGsplatPickGlsl(state.glslGsplatPS));
+    wgslChunks.set('gsplatPS', patchGsplatPickWgsl(state.wgslGsplatPS));
+};
 
-    patchedDevices.add(device);
+const unregisterPickerShaderPatches = (app: AppBase) => {
+    const device = app.graphicsDevice;
+    const state = pickerShaderPatchState.get(device);
+    if (!state) {
+        return;
+    }
+    state.refCount--;
+    if (state.refCount > 0) {
+        return;
+    }
+
+    const glslChunks = ShaderChunks.get(device, 'glsl');
+    const wgslChunks = ShaderChunks.get(device, 'wgsl');
+    glslChunks.set('pickPS', state.glslPickPS);
+    glslChunks.set('gsplatPS', state.glslGsplatPS);
+    wgslChunks.set('pickPS', state.wgslPickPS);
+    wgslChunks.set('gsplatPS', state.wgslGsplatPS);
+    pickerShaderPatchState.delete(device);
 };
 
 const getWorldPoint = (camera: Entity, x: number, y: number, width: number, height: number, normalizedDepth: number) => {
@@ -222,8 +284,8 @@ const getWorldPoint = (camera: Entity, x: number, y: number, width: number, heig
     }
 
     const cam = camera.camera;
-    const near = cam.nearClip;
     const far = cam.farClip;
+    const near = cam.nearClip;
     const ndcDepth = cam.projection === PROJECTION_ORTHOGRAPHIC ?
         normalizedDepth :
         far * normalizedDepth / (normalizedDepth * (far - near) + near);
@@ -243,17 +305,6 @@ const getWorldPoint = (camera: Entity, x: number, y: number, width: number, heig
     return new Vec3(vec4.x, vec4.y, vec4.z);
 };
 
-const decodeDepth = (pixels: Uint8Array): number | null => {
-    const intBits = pixels[0] << 24 | pixels[1] << 16 | pixels[2] << 8 | pixels[3];
-    if (intBits === 0xFFFFFFFF) {
-        return null;
-    }
-
-    int32[0] = intBits;
-    const depth = float32[0];
-    return Number.isFinite(depth) ? depth : null;
-};
-
 class Picker {
     pick: (x: number, y: number) => Promise<Vec3 | null>;
 
@@ -261,22 +312,15 @@ class Picker {
 
     constructor(app: AppBase, camera: Entity) {
         const { graphicsDevice } = app;
-        patchPickChunks(app);
+        registerPickerShaderPatches(app);
 
-        let colorBuffer: Texture;
-        let renderTarget: RenderTarget;
-        let renderPass: RenderPassPicker;
+        let enginePicker: EnginePicker | undefined;
+        let accumBuffer: Texture;
+        let accumTarget: RenderTarget;
+        let accumPass: RenderPassPicker;
 
-        let depthColorBuffer: Texture;
-        let depthBuffer: Texture;
-        let depthRenderTarget: RenderTarget;
-        let depthReadRenderTarget: RenderTarget;
-        let depthRenderPass: RenderPassPicker;
-
-        const emptyMap = new Map<number, MeshInstance | GSplatComponent>();
-
-        const initDepthAccumulation = (width: number, height: number) => {
-            colorBuffer = new Texture(graphicsDevice, {
+        const initRasterAccum = (width: number, height: number) => {
+            accumBuffer = new Texture(graphicsDevice, {
                 format: PIXELFORMAT_RGBA16F,
                 width,
                 height,
@@ -285,50 +329,33 @@ class Picker {
                 magFilter: FILTER_NEAREST,
                 addressU: ADDRESS_CLAMP_TO_EDGE,
                 addressV: ADDRESS_CLAMP_TO_EDGE,
-                name: 'picker'
+                name: 'picker-accum'
             });
 
-            renderTarget = new RenderTarget({
-                colorBuffer,
-                depth: false // not needed - gaussians are rendered back to front
+            accumTarget = new RenderTarget({
+                colorBuffer: accumBuffer,
+                depth: false // not needed — gaussians are rendered back to front
             });
 
-            renderPass = new RenderPassPicker(graphicsDevice, app.renderer);
+            accumPass = new RenderPassPicker(graphicsDevice, app.renderer);
             // RGB: additive depth accumulation. Alpha: multiplicative transmittance.
-            renderPass.blendState = new BlendState(
+            accumPass.blendState = new BlendState(
                 true,
                 BLENDEQUATION_ADD, BLENDMODE_ONE, BLENDMODE_ONE_MINUS_SRC_ALPHA,
                 BLENDEQUATION_ADD, BLENDMODE_ZERO, BLENDMODE_ONE_MINUS_SRC_ALPHA
             );
         };
 
-        const initDepthPick = (width: number, height: number) => {
-            depthColorBuffer = Texture.createDataTexture2D(graphicsDevice, 'pick', width, height, PIXELFORMAT_RGBA8);
-            depthBuffer = Texture.createDataTexture2D(graphicsDevice, 'pick-depth', width, height, PIXELFORMAT_RGBA8);
-
-            depthRenderTarget = new RenderTarget({
-                colorBuffers: [depthColorBuffer, depthBuffer],
-                depth: true
-            });
-
-            depthReadRenderTarget = new RenderTarget({
-                colorBuffer: depthBuffer,
-                depth: false
-            });
-
-            depthRenderPass = new RenderPassPicker(graphicsDevice, app.renderer);
-        };
-
         const readTexture = <T extends Uint8Array | Uint16Array>(
             texture: Texture,
             x: number,
             y: number,
-            renderTarget: RenderTarget
+            target: RenderTarget
         ): Promise<T> => {
-            const texY = graphicsDevice.isWebGL2 ? renderTarget.height - y - 1 : y;
+            const texY = graphicsDevice.isWebGL2 ? target.height - y - 1 : y;
 
             return texture.read(x, texY, 1, 1, {
-                renderTarget,
+                renderTarget: target,
                 immediate: true
             }) as Promise<T>;
         };
@@ -349,74 +376,62 @@ class Picker {
                 return null;
             }
 
+            // enable gsplat IDs only for the duration of the pick so we don't pay the
+            // memory/perf cost between picks (picker instances are typically long-lived).
             const prevEnableIds = app.scene.gsplat.enableIds;
             app.scene.gsplat.enableIds = true;
 
-            let normalizedDepth: number | null = null;
-
             try {
                 if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
-                    if (!depthRenderPass) {
-                        initDepthPick(width, height);
-                    } else {
-                        depthRenderTarget.resize(width, height);
-                        depthReadRenderTarget.resize(width, height);
-                    }
-
-                    depthRenderPass.init(depthRenderTarget);
-                    depthRenderPass.setClearColor(whiteColor);
-                    depthRenderPass.depthStencilOps.clearDepth = true;
-                    depthRenderPass.update(camera.camera, app.scene, [worldLayer], emptyMap, true);
-                    depthRenderPass.render();
-
-                    const pixels = await readTexture<Uint8Array>(depthBuffer, screenX, screenY, depthReadRenderTarget);
-                    normalizedDepth = decodeDepth(pixels);
-                } else {
-                    if (!renderPass) {
-                        initDepthAccumulation(width, height);
-                    } else {
-                        renderTarget.resize(width, height);
-                    }
-
-                    renderPass.init(renderTarget);
-                    renderPass.setClearColor(clearColor);
-                    renderPass.update(camera.camera, app.scene, [worldLayer], emptyMap, false);
-                    renderPass.render();
-
-                    const pixels = await readTexture<Uint16Array>(colorBuffer, screenX, screenY, renderTarget);
-
-                    const r = half2Float(pixels[0]);
-                    const transmittance = half2Float(pixels[3]);
-                    const alpha = 1 - transmittance;
-
-                    if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
-                        normalizedDepth = null;
-                    } else {
-                        normalizedDepth = r / alpha;
-                    }
+                    enginePicker ??= new EnginePicker(app, 1, 1, true);
+                    enginePicker.resize(width, height);
+                    enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
+                    return await enginePicker.getWorldPointAsync(screenX, screenY);
                 }
+
+                if (!accumPass) {
+                    initRasterAccum(width, height);
+                } else {
+                    accumTarget.resize(width, height);
+                }
+
+                accumPass.init(accumTarget);
+                accumPass.setClearColor(clearColor);
+                accumPass.update(
+                    camera.camera,
+                    app.scene,
+                    [worldLayer],
+                    new Map<number, MeshInstance | GSplatComponent>(),
+                    false
+                );
+                accumPass.render();
+
+                const pixels = await readTexture<Uint16Array>(accumBuffer, screenX, screenY, accumTarget);
+
+                const r = half2Float(pixels[0]);
+                const transmittance = half2Float(pixels[3]);
+                const alpha = 1 - transmittance;
+
+                if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
+                    return null;
+                }
+
+                const normalizedDepth = r / alpha;
+                return getWorldPoint(camera, screenX, screenY, width, height, normalizedDepth);
             } finally {
-                // Pick is invoked from user dblclick events, so concurrent invocations
-                // racing on enableIds are not expected in practice.
+                // Pick is only invoked from user dblclick events, so concurrent invocations
+                // (which would race on enableIds) aren't a concern in practice.
                 // eslint-disable-next-line require-atomic-updates
                 app.scene.gsplat.enableIds = prevEnableIds;
             }
-
-            if (normalizedDepth === null) {
-                return null;
-            }
-
-            return getWorldPoint(camera, screenX, screenY, width, height, normalizedDepth);
         };
 
         this.release = () => {
-            renderPass?.destroy();
-            renderTarget?.destroy();
-            colorBuffer?.destroy();
-            depthRenderPass?.destroy();
-            depthRenderTarget?.destroyTextureBuffers();
-            depthRenderTarget?.destroy();
-            depthReadRenderTarget?.destroy();
+            unregisterPickerShaderPatches(app);
+            enginePicker?.destroy();
+            accumPass?.destroy();
+            accumTarget?.destroy();
+            accumBuffer?.destroy();
         };
     }
 }

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -325,6 +325,7 @@ class Picker {
         let accumBuffer: Texture;
         let accumTarget: RenderTarget;
         let accumPass: RenderPassPicker;
+        let chunksPatched = false;
 
         const initRasterAccum = (width: number, height: number) => {
             accumBuffer = new Texture(graphicsDevice, {
@@ -396,7 +397,10 @@ class Picker {
                     return await enginePicker.getWorldPointAsync(screenX, screenY);
                 }
 
-                registerPickerShaderPatches(app);
+                if (!chunksPatched) {
+                    registerPickerShaderPatches(app);
+                    chunksPatched = true;
+                }
 
                 if (!accumPass) {
                     initRasterAccum(width, height);
@@ -436,7 +440,10 @@ class Picker {
         };
 
         this.release = () => {
-            unregisterPickerShaderPatches(app);
+            if (chunksPatched) {
+                unregisterPickerShaderPatches(app);
+                chunksPatched = false;
+            }
             enginePicker?.destroy();
             accumPass?.destroy();
             accumTarget?.destroy();


### PR DESCRIPTION
## Summary

Refactors double-click world picking so the **WebGPU compute** splat path uses the engine’s built-in `Picker` (depth + `getWorldPointAsync`), while **raster** paths (WebGL, CPU/GPU sort, etc.) keep a dedicated **expected-depth** pipeline: patched `pickPS` / `gsplatPS`, `RGBA16F` alpha-weighted depth accumulation, readback, and unproject.

## Motivation

The compute renderer already writes correct expected depth through the tile-composite / depth MRT path; duplicating that in app code was unnecessary. Raster renderers still need the custom shader + accumulation path because the stock pick pass targets splat IDs / last-fragment depth, not expected depth through coverage.

## Changes

- **Compute** (`GSPLAT_RENDERER_COMPUTE`): `EnginePicker(app, 1, 1, true)` → `resize` / `prepare` / `getWorldPointAsync`.
- **Raster**: same behaviour as before, with cleanup:
  - `safeChunkReplace` so gsplat engine chunk patches fail fast if the engine string layout changes
  - Fresh `Map` per pick for `RenderPassPicker` (avoids unbounded growth in the ID mapping)
  - Clearer names (`accumBuffer` / `accumTarget` / `accumPass`) and `readTexture(..., target)` to avoid shadowing
  - Module doc comment describing compute vs raster behaviour

## Notes

- Pick resolution remains full framebuffer size (as before this refactor for expected-depth work).
- `app.scene.gsplat.enableIds` is still toggled for the duration of a pick, matching the prior post–PR-#222 pattern.

## Testing

- [ ] Dblclick pick: default WebGL / raster
- [ ] Dblclick pick: `?compute` (or equivalent) on WebGPU compute path
- [ ] Orbit / fly; ortho vs perspective if applicable
- `npm run lint` (passes); `npm run type:check` (may fail on unrelated pre-existing `viewer.ts` if present)