### PR TITLE
Reintroduce webgpu flag and rename cpu/gpu to cpu-sort/gpu-sort

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -23,7 +23,12 @@
 
             // ?webgpu picks the best WebGPU renderer for the platform: compute on
             // macOS (where the raster gpu-sort path stalls) and gpu-sort elsewhere.
-            const isMac = /Mac/i.test(navigator.platform || navigator.userAgent);
+            // Prefer userAgentData when available, fall back to the deprecated
+            // navigator.platform / userAgent. Exclude iPad desktop mode, which
+            // reports as Mac but should not take the macOS path.
+            const uaPlatform = navigator.userAgentData?.platform || navigator.platform || navigator.userAgent || '';
+            const isIPad = navigator.maxTouchPoints > 1 && /Mac/i.test(navigator.platform || '');
+            const isMac = !isIPad && /macOS|Mac/i.test(uaPlatform);
             const renderer =
                 url.searchParams.has('compute')  ? 'compute' :
                 url.searchParams.has('gpu-sort') ? 'gpu-sort' :

--- a/src/index.html
+++ b/src/index.html
@@ -21,11 +21,15 @@
             const settingsUrl = url.searchParams.has('settings') ? url.searchParams.get('settings') : './settings.json';
             const contentUrl = url.searchParams.has('content') ? url.searchParams.get('content') : './scene.compressed.ply';
 
+            // ?webgpu picks the best WebGPU renderer for the platform: compute on
+            // macOS (where the raster gpu-sort path stalls) and gpu-sort elsewhere.
+            const isMac = /Mac/i.test(navigator.platform || navigator.userAgent);
             const renderer =
-                url.searchParams.has('compute') ? 'compute' :
-                url.searchParams.has('gpu')     ? 'gpu' :
-                url.searchParams.has('cpu')     ? 'cpu' :
-                                                  'webgl';
+                url.searchParams.has('compute')  ? 'compute' :
+                url.searchParams.has('gpu-sort') ? 'gpu-sort' :
+                url.searchParams.has('cpu-sort') ? 'cpu-sort' :
+                url.searchParams.has('webgpu')   ? (isMac ? 'compute' : 'gpu-sort') :
+                                                   'webgl';
 
             const budgetParam = url.searchParams.get('budget');
             const budget = budgetParam !== null ? Number(budgetParam) : undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,8 @@ const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
         powerPreference: 'high-performance'
     });
 
+    console.log(`Renderer: ${device.deviceType}, ${config.renderer === 'webgl' ? 'cpu-sort' : config.renderer}`);
+
     // Set maxPixelRatio so the XR framebuffer scale factor is computed correctly.
     // Regular rendering bypasses maxPixelRatio via the custom initCanvas sizing.
     device.maxPixelRatio = window.devicePixelRatio;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ type Config = {
     fullload: boolean;                          // load all streaming LOD data before first frame
     aa: boolean;                                // render with antialiasing
     budget?: number;                            // override splat budget in millions (overrides platform + performanceMode table)
-    renderer: 'webgl' | 'cpu' | 'gpu' | 'compute';
+    renderer: 'webgl' | 'cpu-sort' | 'gpu-sort' | 'compute';
     heatmap: boolean;                           // render heatmap debug overlay (WebGPU only)
 };
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -75,8 +75,8 @@ fn prepareOutputFromGamma(gammaColor: vec3f, depth: f32) -> vec3f {
 
 const rendererTable: Record<Config['renderer'], number> = {
     'webgl': GSPLAT_RENDERER_RASTER_CPU_SORT,
-    'cpu': GSPLAT_RENDERER_RASTER_CPU_SORT,
-    'gpu': GSPLAT_RENDERER_RASTER_GPU_SORT,
+    'cpu-sort': GSPLAT_RENDERER_RASTER_CPU_SORT,
+    'gpu-sort': GSPLAT_RENDERER_RASTER_GPU_SORT,
     'compute': GSPLAT_RENDERER_COMPUTE
 };
 


### PR DESCRIPTION
## Summary
- Reintroduce the `?webgpu` URL flag, which now picks the best WebGPU renderer per platform: `compute` on macOS (where the raster gpu-sort path stalls) and `gpu-sort` everywhere else.
- Rename the `?cpu` / `?gpu` URL params (and the corresponding `Config['renderer']` values) to `?cpu-sort` / `?gpu-sort` to better reflect what they select.
- Log the resolved graphics device type and renderer to the console at startup to make WebGPU fallbacks easier to diagnose.

## Test plan
- [ ] Load with no flags → device `webgl2`, renderer `cpu-sort`
- [ ] Load with `?webgpu` on macOS → device `webgpu`, renderer `compute`
- [ ] Load with `?webgpu` on Windows/Linux → device `webgpu`, renderer `gpu-sort`
- [ ] Load with `?compute`, `?gpu-sort`, `?cpu-sort` → each forces the named renderer regardless of platform
- [ ] Confirm the console line appears once on startup with the correct values