### PR TITLE
Add trackpad gesture support to orbit, fly, and walk modes

### DIFF
--- a/src/input-controller.ts
+++ b/src/input-controller.ts
@@ -273,7 +273,15 @@ class InputController {
             }
 
             event.preventDefault();
+            // stopImmediatePropagation() blocks KeyboardMouseSource's wheel
+            // handler (also attached to this canvas) so the wheel delta
+            // doesn't double-up on the existing forward/back path. It also
+            // blocks the canvas-level interrupt listener registered below,
+            // so fire the interrupt signal explicitly here to keep parity
+            // with mouse-wheel behavior (cancels camera animations, closes
+            // settings panel, dismisses walk hint).
             event.stopImmediatePropagation();
+            events.fire('inputEvent', 'interrupt', event);
 
             const { deltaX, deltaY } = event;
 

--- a/src/input-controller.ts
+++ b/src/input-controller.ts
@@ -93,7 +93,7 @@ const screenToWorld = (camera: CameraComponent, dx: number, dy: number, dz: numb
 // A single wheel event is unreliable (Magic Mouse, hi-res mice, and macOS
 // Shift-remapping all confuse per-event heuristics), so classify on the
 // first event of a burst and let the rest of the burst inherit that label.
-// A burst is a run of wheel events separated by less than BURST_GAP_MS;
+// A burst is a run of wheel events separated by less than TRACKPAD_BURST_GAP_MS;
 // trackpads stream at ~60Hz (~16ms), wheels emit one event per notch
 // (typically >>50ms apart).
 const TRACKPAD_BURST_GAP_MS = 80;
@@ -261,15 +261,13 @@ class InputController {
             }
 
             const mode = global.state.cameraMode;
+            const hasModifier = event.ctrlKey || event.metaKey || event.shiftKey;
             const isFirstPersonMode = mode === 'fly' || mode === 'walk';
-            const hasZoomModifier = event.ctrlKey || event.metaKey;
 
             if (mode === 'orbit') {
                 // route everything
-            } else if (isFirstPersonMode && !hasZoomModifier) {
-                // route swipes (with or without shift) to look-around;
-                // pinch / Ctrl+swipe fall through to forward/back. Shift is a
-                // WASD speed modifier in these modes, not a gesture modifier.
+            } else if (isFirstPersonMode && !hasModifier) {
+                // route only no-modifier swipes; pinch / shift+swipe fall through
             } else {
                 return;
             }
@@ -287,20 +285,14 @@ class InputController {
 
             const { deltaX, deltaY } = event;
 
-            if (mode === 'orbit') {
-                if (event.ctrlKey || event.metaKey) {
-                    // Pinch-zoom on macOS arrives as ctrl+wheel; ctrl/meta+scroll
-                    // also routes here for keyboard-driven zoom.
-                    this._trackpadZoom += deltaY;
-                } else if (event.shiftKey) {
-                    this._trackpadPan[0] += deltaX;
-                    this._trackpadPan[1] += deltaY;
-                } else {
-                    this._trackpadOrbit[0] += deltaX;
-                    this._trackpadOrbit[1] += deltaY;
-                }
+            if (event.ctrlKey || event.metaKey) {
+                // Pinch-zoom on macOS arrives as ctrl+wheel; ctrl/meta+scroll
+                // also routes here for keyboard-driven zoom.
+                this._trackpadZoom += deltaY;
+            } else if (event.shiftKey) {
+                this._trackpadPan[0] += deltaX;
+                this._trackpadPan[1] += deltaY;
             } else {
-                // fly / walk: always rotate (shift is a speed modifier, not a gesture)
                 this._trackpadOrbit[0] += deltaX;
                 this._trackpadOrbit[1] += deltaY;
             }

--- a/src/input-controller.ts
+++ b/src/input-controller.ts
@@ -89,6 +89,41 @@ const screenToWorld = (camera: CameraComponent, dx: number, dy: number, dz: numb
     return out;
 };
 
+// Distinguish a physical mouse wheel from a trackpad two-finger scroll.
+// A single wheel event is unreliable (Magic Mouse, hi-res mice, and macOS
+// Shift-remapping all confuse per-event heuristics), so classify on the
+// first event of a burst and let the rest of the burst inherit that label.
+// A burst is a run of wheel events separated by less than BURST_GAP_MS;
+// trackpads stream at ~60Hz (~16ms), wheels emit one event per notch
+// (typically >>50ms apart).
+const TRACKPAD_BURST_GAP_MS = 80;
+
+const classifyWheelAsMouse = (event: WheelEvent): boolean => {
+    // Firefox: physical wheels report line/page mode; trackpads report
+    // pixel mode. Firefox doesn't expose wheelDelta* so this is the only
+    // reliable signal there.
+    if (event.deltaMode !== WheelEvent.DOM_DELTA_PIXEL) {
+        return true;
+    }
+    // Chrome / Safari: the non-standard wheelDelta{X,Y} properties preserve
+    // the raw wheel-tick value (always multiples of ±120 per notch)
+    // regardless of macOS scroll smoothing. Trackpads and Magic Mouse emit
+    // arbitrary values that are essentially never aligned to 120.
+    const e = event as WheelEvent & { wheelDeltaX?: number, wheelDeltaY?: number };
+    if (typeof e.wheelDeltaY === 'number' && e.wheelDeltaY !== 0) {
+        return e.wheelDeltaY % 120 === 0;
+    }
+    if (typeof e.wheelDeltaX === 'number' && e.wheelDeltaX !== 0) {
+        return e.wheelDeltaX % 120 === 0;
+    }
+    // Last-resort fallback for browsers without wheelDelta*.
+    const { deltaX, deltaY } = event;
+    if (deltaX !== 0 && deltaY !== 0) {
+        return false;
+    }
+    return Number.isInteger(deltaX) && Number.isInteger(deltaY);
+};
+
 // patch keydown and keyup to ignore events with meta key otherwise
 // keys can get stuck on macOS.
 const patchKeyboardMeta = (desktopInput: any) => {
@@ -186,11 +221,60 @@ class InputController {
 
     gamepadRotateSensitivity: number = 1.0;
 
+    trackpadOrbitSensitivity: number = 0.75;
+
+    trackpadPanSensitivity: number = 1.0;
+
+    trackpadZoomSensitivity: number = 2.0;
+
+    private _lastWheelTime: number = -Infinity;
+
+    private _burstIsMouseWheel: boolean = false;
+
+    private _trackpadOrbit: [number, number] = [0, 0];
+
+    private _trackpadPan: [number, number] = [0, 0];
+
+    private _trackpadZoom: number = 0;
+
     constructor(global: Global) {
         const { app, camera, events, state } = global;
         const canvas = app.graphicsDevice.canvas as HTMLCanvasElement;
 
         patchKeyboardMeta(this._desktopInput);
+
+        // Intercept trackpad wheel events (orbit mode only) before
+        // KeyboardMouseSource sees them, so we can route two-finger scroll to
+        // orbit/pan/zoom instead of just zoom. Physical mouse wheels, fly
+        // mode, and walk mode all fall through to the existing path.
+        canvas.addEventListener('wheel', (event: WheelEvent) => {
+            const now = performance.now();
+            if (now - this._lastWheelTime > TRACKPAD_BURST_GAP_MS) {
+                this._burstIsMouseWheel = classifyWheelAsMouse(event);
+            }
+            this._lastWheelTime = now;
+
+            if (this._burstIsMouseWheel || global.state.cameraMode !== 'orbit') {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopImmediatePropagation();
+
+            const { deltaX, deltaY } = event;
+
+            if (event.ctrlKey || event.metaKey) {
+                // Pinch-zoom on macOS arrives as ctrl+wheel; ctrl/meta+scroll
+                // also routes here for keyboard-driven zoom.
+                this._trackpadZoom += deltaY;
+            } else if (event.shiftKey) {
+                this._trackpadPan[0] += deltaX;
+                this._trackpadPan[1] += deltaY;
+            } else {
+                this._trackpadOrbit[0] += deltaX;
+                this._trackpadOrbit[1] += deltaY;
+            }
+        }, { passive: false });
 
         this._desktopInput.attach(canvas);
         this._orbitInput.attach(canvas);
@@ -579,6 +663,27 @@ class InputController {
         mouseRotate.set(mouse[0], mouse[1], 0);
         v.add(mouseRotate.mulScalar((1 - pan) * this.orbitSpeed * orbitFactor * this.mouseRotateSensitivity * DISPLACEMENT_SCALE));
         deltas.rotate.append([v.x, v.y, v.z]);
+
+        // trackpad (orbit mode only — accumulators are only ever populated there)
+        if (orbit) {
+            // orbit rotate
+            v.set(this._trackpadOrbit[0], this._trackpadOrbit[1], 0);
+            v.mulScalar(this.orbitSpeed * this.trackpadOrbitSensitivity * DISPLACEMENT_SCALE);
+            deltas.rotate.append([v.x, v.y, 0]);
+
+            // pan in world space (matches desktop pan path)
+            const trackPan = screenToWorld(camera, this._trackpadPan[0], this._trackpadPan[1], distance);
+            trackPan.mulScalar(this.trackpadPanSensitivity);
+            deltas.move.append([trackPan.x, trackPan.y, 0]);
+
+            // zoom along z; positive deltaY (scroll-down / pinch-in) → zoom out → +z for orbit
+            const zoomZ = this._trackpadZoom * this.wheelSpeed * this.trackpadZoomSensitivity * DISPLACEMENT_SCALE;
+            deltas.move.append([0, 0, zoomZ]);
+
+            this._trackpadOrbit[0] = this._trackpadOrbit[1] = 0;
+            this._trackpadPan[0] = this._trackpadPan[1] = 0;
+            this._trackpadZoom = 0;
+        }
 
         // mobile move
         v.set(0, 0, 0);

--- a/src/input-controller.ts
+++ b/src/input-controller.ts
@@ -261,13 +261,15 @@ class InputController {
             }
 
             const mode = global.state.cameraMode;
-            const hasModifier = event.ctrlKey || event.metaKey || event.shiftKey;
             const isFirstPersonMode = mode === 'fly' || mode === 'walk';
+            const hasZoomModifier = event.ctrlKey || event.metaKey;
 
             if (mode === 'orbit') {
                 // route everything
-            } else if (isFirstPersonMode && !hasModifier) {
-                // route only no-modifier swipes; pinch / shift+swipe fall through
+            } else if (isFirstPersonMode && !hasZoomModifier) {
+                // route swipes (with or without shift) to look-around;
+                // pinch / Ctrl+swipe fall through to forward/back. Shift is a
+                // WASD speed modifier in these modes, not a gesture modifier.
             } else {
                 return;
             }
@@ -285,14 +287,20 @@ class InputController {
 
             const { deltaX, deltaY } = event;
 
-            if (event.ctrlKey || event.metaKey) {
-                // Pinch-zoom on macOS arrives as ctrl+wheel; ctrl/meta+scroll
-                // also routes here for keyboard-driven zoom.
-                this._trackpadZoom += deltaY;
-            } else if (event.shiftKey) {
-                this._trackpadPan[0] += deltaX;
-                this._trackpadPan[1] += deltaY;
+            if (mode === 'orbit') {
+                if (event.ctrlKey || event.metaKey) {
+                    // Pinch-zoom on macOS arrives as ctrl+wheel; ctrl/meta+scroll
+                    // also routes here for keyboard-driven zoom.
+                    this._trackpadZoom += deltaY;
+                } else if (event.shiftKey) {
+                    this._trackpadPan[0] += deltaX;
+                    this._trackpadPan[1] += deltaY;
+                } else {
+                    this._trackpadOrbit[0] += deltaX;
+                    this._trackpadOrbit[1] += deltaY;
+                }
             } else {
+                // fly / walk: always rotate (shift is a speed modifier, not a gesture)
                 this._trackpadOrbit[0] += deltaX;
                 this._trackpadOrbit[1] += deltaY;
             }

--- a/src/input-controller.ts
+++ b/src/input-controller.ts
@@ -243,10 +243,12 @@ class InputController {
 
         patchKeyboardMeta(this._desktopInput);
 
-        // Intercept trackpad wheel events (orbit mode only) before
-        // KeyboardMouseSource sees them, so we can route two-finger scroll to
-        // orbit/pan/zoom instead of just zoom. Physical mouse wheels, fly
-        // mode, and walk mode all fall through to the existing path.
+        // Intercept trackpad wheel events before KeyboardMouseSource sees
+        // them, so we can route two-finger scroll to orbit/pan/zoom in orbit
+        // mode and to look-around in fly/walk modes. Physical mouse wheels
+        // always fall through. In fly/walk modes only the no-modifier swipe
+        // is intercepted, so pinch (synthetic ctrl) and shift+swipe continue
+        // to drive the existing wheel→forward/back path.
         canvas.addEventListener('wheel', (event: WheelEvent) => {
             const now = performance.now();
             if (now - this._lastWheelTime > TRACKPAD_BURST_GAP_MS) {
@@ -254,7 +256,19 @@ class InputController {
             }
             this._lastWheelTime = now;
 
-            if (this._burstIsMouseWheel || global.state.cameraMode !== 'orbit') {
+            if (this._burstIsMouseWheel) {
+                return;
+            }
+
+            const mode = global.state.cameraMode;
+            const hasModifier = event.ctrlKey || event.metaKey || event.shiftKey;
+            const isFirstPersonMode = mode === 'fly' || mode === 'walk';
+
+            if (mode === 'orbit') {
+                // route everything
+            } else if (isFirstPersonMode && !hasModifier) {
+                // route only no-modifier swipes; pinch / shift+swipe fall through
+            } else {
                 return;
             }
 
@@ -664,7 +678,7 @@ class InputController {
         v.add(mouseRotate.mulScalar((1 - pan) * this.orbitSpeed * orbitFactor * this.mouseRotateSensitivity * DISPLACEMENT_SCALE));
         deltas.rotate.append([v.x, v.y, v.z]);
 
-        // trackpad (orbit mode only — accumulators are only ever populated there)
+        // trackpad
         if (orbit) {
             // orbit rotate
             v.set(this._trackpadOrbit[0], this._trackpadOrbit[1], 0);
@@ -679,11 +693,18 @@ class InputController {
             // zoom along z; positive deltaY (scroll-down / pinch-in) → zoom out → +z for orbit
             const zoomZ = this._trackpadZoom * this.wheelSpeed * this.trackpadZoomSensitivity * DISPLACEMENT_SCALE;
             deltas.move.append([0, 0, zoomZ]);
-
-            this._trackpadOrbit[0] = this._trackpadOrbit[1] = 0;
-            this._trackpadPan[0] = this._trackpadPan[1] = 0;
-            this._trackpadZoom = 0;
+        } else if (isFirstPerson) {
+            // fly / walk look-around (only the no-modifier swipe is
+            // captured; pinch / shift fall through to the existing
+            // wheel→forward path)
+            v.set(this._trackpadOrbit[0], this._trackpadOrbit[1], 0);
+            v.mulScalar(this.orbitSpeed * orbitFactor * this.trackpadOrbitSensitivity * DISPLACEMENT_SCALE);
+            deltas.rotate.append([v.x, v.y, 0]);
         }
+
+        this._trackpadOrbit[0] = this._trackpadOrbit[1] = 0;
+        this._trackpadPan[0] = this._trackpadPan[1] = 0;
+        this._trackpadZoom = 0;
 
         // mobile move
         v.set(0, 0, 0);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -258,11 +258,24 @@ const initUI = (global: Global) => {
     });
 
     // Forward wheel events from UI overlays to the canvas so the camera zooms
-    // instead of the page scrolling (e.g. annotation nav, tooltips, hotspots)
+    // instead of the page scrolling (e.g. annotation nav, tooltips, hotspots).
+    // The non-standard wheelDelta{X,Y} properties aren't part of WheelEventInit,
+    // so they get dropped by `new WheelEvent(type, init)`. We re-attach them so
+    // the trackpad-vs-mouse classifier in input-controller.ts behaves the same
+    // whether the event originated on the canvas or was forwarded from the UI.
     const canvas = global.app.graphicsDevice.canvas as HTMLCanvasElement;
     dom.ui.addEventListener('wheel', (event: WheelEvent) => {
         event.preventDefault();
-        canvas.dispatchEvent(new WheelEvent(event.type, event));
+        const forwarded = new WheelEvent(event.type, event);
+        const src = event as WheelEvent & {
+            wheelDelta?: number, wheelDeltaX?: number, wheelDeltaY?: number
+        };
+        for (const key of ['wheelDelta', 'wheelDeltaX', 'wheelDeltaY'] as const) {
+            if (typeof src[key] === 'number') {
+                Object.defineProperty(forwarded, key, { value: src[key], configurable: true });
+            }
+        }
+        canvas.dispatchEvent(forwarded);
     }, { passive: false });
 
     // Handle loading progress updates


### PR DESCRIPTION
## Summary
- Trackpad two-finger gestures now drive camera input across all three
  modes instead of always zooming.
  - **Orbit:** swipe orbits, Shift+swipe pans, pinch / Ctrl+swipe zooms.
  - **Fly / Walk:** no-modifier swipe looks around. Pinch and Shift+swipe
    keep their existing forward/back behavior.
- Physical mouse wheels, mouse drag, keyboard, touch, and gamepad input
  are unchanged in every mode.

## How it works
A new `wheel` listener registered before PlayCanvas's `KeyboardMouseSource`
classifies each burst as trackpad vs. physical mouse wheel using the same
heuristics as the supersplat editor (Firefox `deltaMode`, Chrome/Safari
`wheelDeltaY % 120`, 80 ms burst-gap timing). Mouse-wheel bursts always
fall through. Trackpad bursts are routed into per-frame accumulators that
feed the existing `deltas.rotate` / `deltas.move` paths, so damping and
frame-rate behavior match mouse drag.

In fly and walk modes only the no-modifier trackpad swipe is intercepted
(routed to look-around). Modifier-bearing trackpad events keep flowing
through `KeyboardMouseSource` to preserve forward/back movement.

## Caveat
The classifier flags non-quantized wheel deltas as trackpad, which means
**Magic Mouse and other high-resolution smooth-scroll mice** will be
treated as a trackpad. In orbit mode plain vertical scroll will orbit
instead of zoom; in fly/walk it will look instead of moving forward.
Hold Ctrl/⌘ to fall back to zoom / forward on those devices. This is the
same trade-off the supersplat editor already makes; no reliable signal
exists to distinguish a Magic Mouse from a trackpad.

## Test plan
- [ ] Orbit: two-finger swipe → orbits
- [ ] Orbit: Shift + swipe → pans
- [ ] Orbit: pinch and Ctrl/⌘ + swipe → zoom
- [ ] Fly: two-finger swipe → looks around
- [ ] Fly: pinch / Shift+swipe → still moves forward/back
- [ ] Fly: WASD, mouse drag, mouse wheel → unchanged
- [ ] Walk: two-finger swipe → looks around (with and without gaming controls)
- [ ] Walk: pinch / Shift+swipe → still moves forward/back
- [ ] Walk: pointer-lock + gaming controls + trackpad look → no conflicts;
      tap-to-walk and click-to-walk unaffected
- [ ] Mouse wheel zooms (orbit) and moves forward/back (fly, walk)
- [ ] LMB / MMB / RMB drag → unchanged in all modes
- [ ] Mobile pinch / two-finger pan → unchanged
- [ ] Rapid alternation between mouse wheel and trackpad classifies each
      burst correctly
- [ ] Magic Mouse: confirm orbit-on-scroll / look-on-scroll behavior is
      acceptable and Ctrl-scroll still zooms / moves