### PR TITLE
Add debug overlay for GLB collision meshes

### DIFF
--- a/src/collision/index.ts
+++ b/src/collision/index.ts
@@ -1,3 +1,4 @@
 export type { Collision, PushOut, RayHit } from './collision';
 export { MeshCollision } from './mesh-collision';
+export type { TriangleSoA } from './mesh-collision';
 export { VoxelCollision, loadVoxelCollision } from './voxel-collision';

--- a/src/collision/mesh-collision.ts
+++ b/src/collision/mesh-collision.ts
@@ -33,9 +33,11 @@ interface TriangleData {
     count: number;
 }
 
-// Public read-only view of triangle data, exposed for debug overlays. Keys
-// match the internal TriangleData layout but the typed arrays are presented
-// as readonly to discourage mutation.
+// Public view of the triangle SoA exposed by MeshCollision for debug
+// overlays. The `readonly` qualifiers only prevent reassigning the *fields*;
+// callers can technically still mutate the underlying typed arrays. By
+// convention the buffers are owned by the collision and must not be written
+// to — they back live BVH / collision queries.
 interface TriangleSoA {
     readonly v0x: Float32Array; readonly v0y: Float32Array; readonly v0z: Float32Array;
     readonly v1x: Float32Array; readonly v1y: Float32Array; readonly v1z: Float32Array;

--- a/src/collision/mesh-collision.ts
+++ b/src/collision/mesh-collision.ts
@@ -330,6 +330,12 @@ const _segClosest = { x: 0, y: 0, z: 0 };
 const _triClosest = { x: 0, y: 0, z: 0 };
 
 class MeshCollision implements Collision {
+    // Source geometry retained so debug overlays can build a wireframe from the
+    // same triangles that drive collision queries.
+    readonly positions: Float32Array;
+
+    readonly indices: Uint32Array | Uint16Array;
+
     private _tris: TriangleData;
 
     private _root: BVHNode;
@@ -349,6 +355,8 @@ class MeshCollision implements Collision {
     private readonly _rayResult = { t: -1, triIdx: -1 };
 
     constructor(positions: Float32Array, indices: Uint32Array | Uint16Array) {
+        this.positions = positions;
+        this.indices = indices;
         const numTris = Math.floor(indices.length / 3);
         const tris: TriangleData = {
             v0x: new Float32Array(numTris),

--- a/src/collision/mesh-collision.ts
+++ b/src/collision/mesh-collision.ts
@@ -33,6 +33,17 @@ interface TriangleData {
     count: number;
 }
 
+// Public read-only view of triangle data, exposed for debug overlays. Keys
+// match the internal TriangleData layout but the typed arrays are presented
+// as readonly to discourage mutation.
+interface TriangleSoA {
+    readonly v0x: Float32Array; readonly v0y: Float32Array; readonly v0z: Float32Array;
+    readonly v1x: Float32Array; readonly v1y: Float32Array; readonly v1z: Float32Array;
+    readonly v2x: Float32Array; readonly v2y: Float32Array; readonly v2z: Float32Array;
+    readonly nx: Float32Array; readonly ny: Float32Array; readonly nz: Float32Array;
+    readonly count: number;
+}
+
 // ---- BVH construction ----
 
 const MAX_LEAF_TRIS = 4;
@@ -330,12 +341,6 @@ const _segClosest = { x: 0, y: 0, z: 0 };
 const _triClosest = { x: 0, y: 0, z: 0 };
 
 class MeshCollision implements Collision {
-    // Source geometry retained so debug overlays can build a wireframe from the
-    // same triangles that drive collision queries.
-    readonly positions: Float32Array;
-
-    readonly indices: Uint32Array | Uint16Array;
-
     private _tris: TriangleData;
 
     private _root: BVHNode;
@@ -355,8 +360,6 @@ class MeshCollision implements Collision {
     private readonly _rayResult = { t: -1, triIdx: -1 };
 
     constructor(positions: Float32Array, indices: Uint32Array | Uint16Array) {
-        this.positions = positions;
-        this.indices = indices;
         const numTris = Math.floor(indices.length / 3);
         const tris: TriangleData = {
             v0x: new Float32Array(numTris),
@@ -406,6 +409,18 @@ class MeshCollision implements Collision {
 
         this._tris = tris;
         this._root = buildBVH(tris, 0, numTris);
+    }
+
+    // ---- Public accessors ----
+
+    /**
+     * Read-only view of the de-indexed triangle data, used by debug overlays.
+     * The underlying typed arrays are reused and must not be mutated.
+     *
+     * @returns the triangle SoA backing this collision.
+     */
+    get triangles(): TriangleSoA {
+        return this._tris;
     }
 
     // ---- Collision interface ----
@@ -873,3 +888,4 @@ class MeshCollision implements Collision {
 }
 
 export { MeshCollision };
+export type { TriangleSoA };

--- a/src/index.html
+++ b/src/index.html
@@ -148,7 +148,7 @@
                             </svg>
                         </button>
 
-                        <button id="showVoxels" class="controlButton hidden">
+                        <button id="showCollision" class="controlButton hidden">
                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
                                 <g class='stroke'><use href="#voxelIcon"/></g>
                                 <g class='fill'><use href="#voxelIcon"/></g>

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,8 +223,8 @@ const main = async (canvas: HTMLCanvasElement, settingsJson: any, config: Config
         hasAR: false,
         hasVR: false,
         hasCollision: false,
-        hasVoxelOverlay: false,
-        voxelOverlayEnabled: false,
+        hasCollisionOverlay: false,
+        collisionOverlayEnabled: false,
         isFullscreen: false,
         controlsHidden: false,
         gamingControls: localStorage.getItem('gamingControls') === 'true'

--- a/src/input/app/mode-shortcuts.ts
+++ b/src/input/app/mode-shortcuts.ts
@@ -44,8 +44,8 @@ class ModeShortcuts {
                 events.fire('inputEvent', 'toggleWalk');
                 break;
             case 'v':
-                if (state.hasVoxelOverlay) {
-                    state.voxelOverlayEnabled = !state.voxelOverlayEnabled;
+                if (state.hasCollisionOverlay) {
+                    state.collisionOverlayEnabled = !state.collisionOverlayEnabled;
                 }
                 break;
             case 'g':

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -1,7 +1,8 @@
 import {
     type AppBase,
     BLEND_NONE,
-    BLEND_PREMULTIPLIED,
+    BLEND_NORMAL,
+    Color,
     CULLFACE_BACK,
     CULLFACE_NONE,
     Entity,
@@ -12,144 +13,35 @@ import {
     MeshInstance,
     PRIMITIVE_TRIANGLES,
     RENDERSTYLE_WIREFRAME,
-    SEMANTIC_NORMAL,
-    SEMANTIC_POSITION,
-    ShaderMaterial,
-    SORTMODE_MANUAL
+    SORTMODE_MANUAL,
+    StandardMaterial
 } from 'playcanvas';
 
 import type { MeshCollision } from './collision';
 
-// Single-layer overlay rendered after the gaussian splats:
+// Single-layer overlay rendered after the gaussians, three passes on a fresh
+// depth buffer, all using stock StandardMaterial:
 //
-//   1. Layer clears the depth buffer (color is left untouched) so the mesh
-//      has a fresh depth context.
-//   2. Surface depth pre-pass: the collision mesh renders with color writes
-//      disabled and depth test/write on, establishing the front-most surface
-//      depth at each pixel.
-//   3. Surface color pass: the same mesh renders again with depthFunc EQUAL
-//      and depth write off, so only the front-most fragment from pass 2
-//      survives. Premultiplied alpha blends that one fragment onto the camera
-//      target — no order-dependent overdraw inside the mesh.
-//   4. Wireframe pass: black lines (RENDERSTYLE_WIREFRAME), depth-tested
+//   1. Surface depth pre-pass: depth test/write on, color writes off — stamps
+//      the front-most surface depth into the depth buffer.
+//   2. Surface color pass: depthFunc EQUAL, depth write off — only the
+//      front-most fragment from pass 1 survives, so a single layer of
+//      semi-transparent surface color blends onto the camera target. Tint is
+//      baked per-vertex from each triangle's face normal at construction
+//      time, so no custom shader is needed.
+//   3. Wireframe pass: black lines (RENDERSTYLE_WIREFRAME) depth-tested
 //      against the surface depth so back-facing edges are hidden.
-//
-// Per-triangle flat normals are baked into the vertex buffer (un-welded
-// vertices) to avoid derivative shimmer at triangle boundaries.
 
-const surfaceVertexGLSL = /* glsl */ `
-    attribute vec3 vertex_position;
-    attribute vec3 vertex_normal;
-    uniform mat4 matrix_model;
-    uniform mat4 matrix_viewProjection;
-    uniform mat3 matrix_normal;
-    varying vec3 vNormal;
-    void main(void) {
-        vNormal = normalize(matrix_normal * vertex_normal);
-        gl_Position = matrix_viewProjection * (matrix_model * vec4(vertex_position, 1.0));
-    }
-`;
+const SURFACE_ALPHA = 0.3;
 
-const surfaceFragmentGLSL = /* glsl */ `
-    varying vec3 vNormal;
-    void main(void) {
-        vec3 n = abs(normalize(vNormal));
-        vec3 color;
-        if (n.x > n.y && n.x > n.z) {
-            color = vec3(0.85);
-        } else if (n.y > n.z) {
-            color = vec3(0.55);
-        } else {
-            color = vec3(0.3);
-        }
-        float alpha = 0.55;
-        gl_FragColor = vec4(color * alpha, alpha);
-    }
-`;
-
-const surfaceVertexWGSL = /* wgsl */ `
-    attribute vertex_position: vec3f;
-    attribute vertex_normal: vec3f;
-    uniform matrix_model: mat4x4f;
-    uniform matrix_viewProjection: mat4x4f;
-    uniform matrix_normal: mat3x3f;
-    varying vNormal: vec3f;
-    @vertex fn vertexMain(input: VertexInput) -> VertexOutput {
-        var output: VertexOutput;
-        output.vNormal = normalize(uniform.matrix_normal * input.vertex_normal);
-        output.position = uniform.matrix_viewProjection * (uniform.matrix_model * vec4f(input.vertex_position, 1.0));
-        return output;
-    }
-`;
-
-const surfaceFragmentWGSL = /* wgsl */ `
-    varying vNormal: vec3f;
-    @fragment fn fragmentMain(input: FragmentInput) -> FragmentOutput {
-        var output: FragmentOutput;
-        let n = abs(normalize(input.vNormal));
-        var color: vec3f;
-        if (n.x > n.y && n.x > n.z) {
-            color = vec3f(0.85);
-        } else if (n.y > n.z) {
-            color = vec3f(0.55);
-        } else {
-            color = vec3f(0.3);
-        }
-        let alpha = 0.55;
-        output.color = vec4f(color * alpha, alpha);
-        return output;
-    }
-`;
-
-// Position-only vertex shader for the depth pre-pass and the wireframe.
-// Includes a dummy varying so PlayCanvas emits the WGSL FragmentInput struct.
-const positionOnlyVertexGLSL = /* glsl */ `
-    attribute vec3 vertex_position;
-    uniform mat4 matrix_model;
-    uniform mat4 matrix_viewProjection;
-    varying float vDummy;
-    void main(void) {
-        vDummy = 0.0;
-        gl_Position = matrix_viewProjection * (matrix_model * vec4(vertex_position, 1.0));
-    }
-`;
-
-const positionOnlyVertexWGSL = /* wgsl */ `
-    attribute vertex_position: vec3f;
-    uniform matrix_model: mat4x4f;
-    uniform matrix_viewProjection: mat4x4f;
-    varying vDummy: f32;
-    @vertex fn vertexMain(input: VertexInput) -> VertexOutput {
-        var output: VertexOutput;
-        output.vDummy = 0.0;
-        output.position = uniform.matrix_viewProjection * (uniform.matrix_model * vec4f(input.vertex_position, 1.0));
-        return output;
-    }
-`;
-
-const constantBlackFragmentGLSL = /* glsl */ `
-    varying float vDummy;
-    void main(void) {
-        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
-    }
-`;
-
-const constantBlackFragmentWGSL = /* wgsl */ `
-    varying vDummy: f32;
-    @fragment fn fragmentMain(input: FragmentInput) -> FragmentOutput {
-        var output: FragmentOutput;
-        output.color = vec4f(0.0, 0.0, 0.0, 1.0);
-        return output;
-    }
-`;
-
-// Build an unindexed mesh where every triangle has three unique vertices, each
-// carrying that triangle's flat face normal. This trades ~3x vertex memory for
-// stable per-fragment shading with no derivative artifacts.
+// Build an unindexed mesh where every triangle has three unique vertices that
+// share the triangle's flat face color (tint by dominant axis of the face
+// normal, alpha baked in). Using per-triangle vertices avoids derivative
+// shimmer and gives the surface a faceted look matching the voxel overlay.
 const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Array) => {
     const numTris = Math.floor(indices.length / 3);
     const flatPositions = new Float32Array(numTris * 9);
-    const flatNormals = new Float32Array(numTris * 9);
+    const flatColors = new Float32Array(numTris * 12);
     const flatIndices = new Uint32Array(numTris * 3);
 
     for (let i = 0; i < numTris; i++) {
@@ -163,31 +55,52 @@ const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Arr
 
         const e1x = v1x - v0x, e1y = v1y - v0y, e1z = v1z - v0z;
         const e2x = v2x - v0x, e2y = v2y - v0y, e2z = v2z - v0z;
-        let nx = e1y * e2z - e1z * e2y;
-        let ny = e1z * e2x - e1x * e2z;
-        let nz = e1x * e2y - e1y * e2x;
-        const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
-        if (len > 1e-10) {
-            const inv = 1 / len;
-            nx *= inv; ny *= inv; nz *= inv;
+        const nx = e1y * e2z - e1z * e2y;
+        const ny = e1z * e2x - e1x * e2z;
+        const nz = e1x * e2y - e1y * e2x;
+
+        const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz);
+        let gray;
+        if (ax > ay && ax > az) {
+            gray = 0.85;
+        } else if (ay > az) {
+            gray = 0.55;
+        } else {
+            gray = 0.3;
         }
 
-        const o = i * 9;
-        flatPositions[o]     = v0x; flatPositions[o + 1] = v0y; flatPositions[o + 2] = v0z;
-        flatPositions[o + 3] = v1x; flatPositions[o + 4] = v1y; flatPositions[o + 5] = v1z;
-        flatPositions[o + 6] = v2x; flatPositions[o + 7] = v2y; flatPositions[o + 8] = v2z;
+        const op = i * 9;
+        flatPositions[op]     = v0x; flatPositions[op + 1] = v0y; flatPositions[op + 2] = v0z;
+        flatPositions[op + 3] = v1x; flatPositions[op + 4] = v1y; flatPositions[op + 5] = v1z;
+        flatPositions[op + 6] = v2x; flatPositions[op + 7] = v2y; flatPositions[op + 8] = v2z;
 
-        flatNormals[o]     = nx; flatNormals[o + 1] = ny; flatNormals[o + 2] = nz;
-        flatNormals[o + 3] = nx; flatNormals[o + 4] = ny; flatNormals[o + 5] = nz;
-        flatNormals[o + 6] = nx; flatNormals[o + 7] = ny; flatNormals[o + 8] = nz;
+        const oc = i * 12;
+        for (let j = 0; j < 3; j++) {
+            const k = oc + j * 4;
+            flatColors[k]     = gray;
+            flatColors[k + 1] = gray;
+            flatColors[k + 2] = gray;
+            flatColors[k + 3] = SURFACE_ALPHA;
+        }
 
         const oi = i * 3;
-        flatIndices[oi] = oi;
+        flatIndices[oi]     = oi;
         flatIndices[oi + 1] = oi + 1;
         flatIndices[oi + 2] = oi + 2;
     }
 
-    return { flatPositions, flatNormals, flatIndices };
+    return { flatPositions, flatColors, flatIndices };
+};
+
+const makeUnlit = () => {
+    const m = new StandardMaterial();
+    m.useLighting = false;
+    m.useSkybox = false;
+    m.ambient = new Color(0, 0, 0);
+    m.diffuse = new Color(0, 0, 0);
+    m.specular = new Color(0, 0, 0);
+    m.emissive = new Color(0, 0, 0);
+    return m;
 };
 
 class MeshDebugOverlay {
@@ -201,17 +114,17 @@ class MeshDebugOverlay {
         const device = app.graphicsDevice;
         const { positions, indices } = collision;
 
-        const { flatPositions, flatNormals, flatIndices } = buildFlatMesh(positions, indices);
+        const { flatPositions, flatColors, flatIndices } = buildFlatMesh(positions, indices);
 
         const mesh = new Mesh(device);
         mesh.setPositions(flatPositions);
-        mesh.setNormals(flatNormals);
+        mesh.setColors(flatColors);
         mesh.setIndices(flatIndices);
         mesh.update(PRIMITIVE_TRIANGLES);
         mesh.generateWireframe();
 
-        // One overlay layer rendered after everything, with a fresh depth
-        // buffer. Manual sort lets the three passes execute in drawOrder.
+        // Overlay layer rendered after everything, with a fresh depth buffer.
+        // Manual sort keeps the three passes ordered by drawOrder.
         this.layer = new Layer({
             name: 'CollisionOverlay',
             clearColorBuffer: false,
@@ -222,24 +135,16 @@ class MeshDebugOverlay {
         app.scene.layers.push(this.layer);
         camera.camera.layers = [...camera.camera.layers, this.layer.id];
 
-        // Pass 1: depth pre-pass. No color writes, normal depth test/write.
-        const depthMaterial = new ShaderMaterial();
-        depthMaterial.cull = CULLFACE_BACK;
+        // Pass 1: depth pre-pass. No color writes.
+        const depthMaterial = makeUnlit();
         depthMaterial.blendType = BLEND_NONE;
         depthMaterial.depthTest = true;
         depthMaterial.depthWrite = true;
+        depthMaterial.cull = CULLFACE_BACK;
         depthMaterial.redWrite = false;
         depthMaterial.greenWrite = false;
         depthMaterial.blueWrite = false;
         depthMaterial.alphaWrite = false;
-        depthMaterial.shaderDesc = {
-            uniqueName: 'CollisionDepthPrepass',
-            vertexGLSL: positionOnlyVertexGLSL,
-            fragmentGLSL: constantBlackFragmentGLSL,
-            vertexWGSL: positionOnlyVertexWGSL,
-            fragmentWGSL: constantBlackFragmentWGSL,
-            attributes: { vertex_position: SEMANTIC_POSITION }
-        };
         depthMaterial.update();
 
         const depthInstance = new MeshInstance(mesh, depthMaterial);
@@ -251,26 +156,20 @@ class MeshDebugOverlay {
             layers: [this.layer.id]
         });
 
-        // Pass 2: color pass with depth EQUAL. Only the front-most fragment
-        // from pass 1 survives, so premultiplied alpha blends a single layer
-        // of mesh color onto the camera target.
-        const surfaceMaterial = new ShaderMaterial();
-        surfaceMaterial.cull = CULLFACE_BACK;
-        surfaceMaterial.blendType = BLEND_PREMULTIPLIED;
+        // Pass 2: surface color, depth EQUAL. Vertex color drives both the
+        // emissive tint and the opacity, no shaders required.
+        const surfaceMaterial = makeUnlit();
+        surfaceMaterial.emissive = new Color(1, 1, 1);
+        surfaceMaterial.emissiveVertexColor = true;
+        surfaceMaterial.emissiveVertexColorChannel = 'rgb';
+        surfaceMaterial.opacityVertexColor = true;
+        surfaceMaterial.opacityVertexColorChannel = 'a';
+        surfaceMaterial.opacity = 1;
+        surfaceMaterial.blendType = BLEND_NORMAL;
         surfaceMaterial.depthTest = true;
         surfaceMaterial.depthFunc = FUNC_EQUAL;
         surfaceMaterial.depthWrite = false;
-        surfaceMaterial.shaderDesc = {
-            uniqueName: 'CollisionSurface',
-            vertexGLSL: surfaceVertexGLSL,
-            fragmentGLSL: surfaceFragmentGLSL,
-            vertexWGSL: surfaceVertexWGSL,
-            fragmentWGSL: surfaceFragmentWGSL,
-            attributes: {
-                vertex_position: SEMANTIC_POSITION,
-                vertex_normal: SEMANTIC_NORMAL
-            }
-        };
+        surfaceMaterial.cull = CULLFACE_BACK;
         surfaceMaterial.update();
 
         const surfaceInstance = new MeshInstance(mesh, surfaceMaterial);
@@ -282,23 +181,14 @@ class MeshDebugOverlay {
             layers: [this.layer.id]
         });
 
-        // Pass 3: wireframe — black lines depth-tested against the surface so
-        // back-facing edges are hidden. LESSEQUAL keeps front-edge lines from
-        // failing against the depth their own surface wrote.
-        const wireframeMaterial = new ShaderMaterial();
-        wireframeMaterial.cull = CULLFACE_NONE;
+        // Pass 3: wireframe, opaque black, depth-tested against the surface.
+        const wireframeMaterial = makeUnlit();
+        wireframeMaterial.opacity = 1;
         wireframeMaterial.blendType = BLEND_NONE;
         wireframeMaterial.depthTest = true;
         wireframeMaterial.depthFunc = FUNC_LESSEQUAL;
         wireframeMaterial.depthWrite = false;
-        wireframeMaterial.shaderDesc = {
-            uniqueName: 'CollisionWireframeFlat',
-            vertexGLSL: positionOnlyVertexGLSL,
-            fragmentGLSL: constantBlackFragmentGLSL,
-            vertexWGSL: positionOnlyVertexWGSL,
-            fragmentWGSL: constantBlackFragmentWGSL,
-            attributes: { vertex_position: SEMANTIC_POSITION }
-        };
+        wireframeMaterial.cull = CULLFACE_NONE;
         wireframeMaterial.update();
 
         const wireframeInstance = new MeshInstance(mesh, wireframeMaterial);

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -148,12 +148,18 @@ class MeshDebugOverlay {
         camera.camera.layers = [...camera.camera.layers, this.layer.id];
 
         // Pass 1: depth pre-pass. Color writes masked off so only depth lands
-        // in the buffer.
+        // in the buffer. Both this and pass 2 use the same depthBias /
+        // slopeDepthBias so they write/test identical depth values
+        // (FUNC_EQUAL relies on this) while still sitting slightly behind the
+        // wireframe lines so pass 3's FUNC_LESSEQUAL passes reliably without
+        // z-fighting.
         const depthMaterial = makeSurfaceMaterial();
         depthMaterial.cull = CULLFACE_BACK;
         depthMaterial.blendType = BLEND_NORMAL;
         depthMaterial.depthTest = true;
         depthMaterial.depthWrite = true;
+        depthMaterial.depthBias = 1;
+        depthMaterial.slopeDepthBias = 1;
         depthMaterial.redWrite = false;
         depthMaterial.greenWrite = false;
         depthMaterial.blueWrite = false;
@@ -178,6 +184,8 @@ class MeshDebugOverlay {
         surfaceMaterial.depthTest = true;
         surfaceMaterial.depthFunc = FUNC_EQUAL;
         surfaceMaterial.depthWrite = false;
+        surfaceMaterial.depthBias = 1;
+        surfaceMaterial.slopeDepthBias = 1;
         surfaceMaterial.update();
 
         const surfaceInstance = new MeshInstance(mesh, surfaceMaterial);

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -1,12 +1,13 @@
 import {
     type AppBase,
-    BLEND_NORMAL,
+    BLEND_NONE,
     Color,
     CULLFACE_NONE,
     Entity,
     Mesh,
     MeshInstance,
-    PRIMITIVE_LINES,
+    PRIMITIVE_TRIANGLES,
+    RENDERSTYLE_WIREFRAME,
     StandardMaterial
 } from 'playcanvas';
 
@@ -19,41 +20,32 @@ class MeshDebugOverlay {
 
     constructor(app: AppBase, collision: MeshCollision) {
         const { positions, indices } = collision;
-        const numTris = Math.floor(indices.length / 3);
 
-        // Each triangle becomes 3 line segments (6 indices).
-        const lineIndices = new Uint32Array(numTris * 6);
-        for (let i = 0; i < numTris; i++) {
-            const i0 = indices[i * 3];
-            const i1 = indices[i * 3 + 1];
-            const i2 = indices[i * 3 + 2];
-            const o = i * 6;
-            lineIndices[o]     = i0; lineIndices[o + 1] = i1;
-            lineIndices[o + 2] = i1; lineIndices[o + 3] = i2;
-            lineIndices[o + 4] = i2; lineIndices[o + 5] = i0;
-        }
-
+        // Build a triangle mesh and let the engine generate a line index buffer
+        // for it. RENDERSTYLE_WIREFRAME selects that secondary index buffer.
         const mesh = new Mesh(app.graphicsDevice);
         mesh.setPositions(positions);
-        mesh.setIndices(lineIndices);
-        mesh.update(PRIMITIVE_LINES);
+        mesh.setIndices(indices instanceof Uint32Array ? indices : new Uint32Array(indices));
+        mesh.update(PRIMITIVE_TRIANGLES);
+        mesh.generateWireframe();
 
         const material = new StandardMaterial();
         material.useLighting = false;
         material.diffuse = new Color(0, 0, 0);
-        material.emissive = new Color(1.0, 0.25, 0.2);
-        material.opacity = 0.85;
-        material.blendType = BLEND_NORMAL;
-        material.depthTest = false;
-        material.depthWrite = false;
+        material.emissive = new Color(0, 0, 0);
+        material.blendType = BLEND_NONE;
+        material.depthTest = true;
+        material.depthWrite = true;
         material.cull = CULLFACE_NONE;
         material.update();
 
         const meshInstance = new MeshInstance(mesh, material);
-        meshInstance.cull = false;
 
         this.entity = new Entity('MeshCollisionDebug');
         this.entity.addComponent('render', { meshInstances: [meshInstance] });
+        // The render component overwrites each meshInstance.renderStyle with
+        // its own value, so set it on the component after the component exists.
+        this.entity.render.renderStyle = RENDERSTYLE_WIREFRAME;
         this.entity.enabled = false;
         app.root.addChild(this.entity);
     }

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -37,7 +37,7 @@ import type { MeshCollision } from './collision';
 // of them — if the depth pre-pass were opaque, the transparent action would
 // wipe the depth before pass 2 and FUNC_EQUAL would always fail.
 
-const SURFACE_ALPHA = 0.3;
+const SURFACE_ALPHA = Math.round(0.3 * 255);
 
 // Build an unindexed mesh where every triangle has three unique vertices that
 // share the triangle's flat face color (tint by dominant axis of the face
@@ -46,7 +46,7 @@ const SURFACE_ALPHA = 0.3;
 const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Array) => {
     const numTris = Math.floor(indices.length / 3);
     const flatPositions = new Float32Array(numTris * 9);
-    const flatColors = new Float32Array(numTris * 12);
+    const flatColors = new Uint8Array(numTris * 12);
     const flatIndices = new Uint32Array(numTris * 3);
 
     for (let i = 0; i < numTris; i++) {
@@ -67,11 +67,11 @@ const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Arr
         const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz);
         let gray;
         if (ax > ay && ax > az) {
-            gray = 0.85;
+            gray = 217; // 0.85 * 255
         } else if (ay > az) {
-            gray = 0.55;
+            gray = 140; // 0.55 * 255
         } else {
-            gray = 0.3;
+            gray = 76;  // 0.30 * 255
         }
 
         const op = i * 9;
@@ -118,6 +118,10 @@ const makeSurfaceMaterial = () => {
 };
 
 class MeshDebugOverlay {
+    private app: AppBase;
+
+    private camera: Entity;
+
     private layer: Layer;
 
     private entity: Entity;
@@ -125,6 +129,8 @@ class MeshDebugOverlay {
     private _enabled = false;
 
     constructor(app: AppBase, collision: MeshCollision, camera: Entity) {
+        this.app = app;
+        this.camera = camera;
         const device = app.graphicsDevice;
         const { positions, indices } = collision;
 
@@ -132,7 +138,7 @@ class MeshDebugOverlay {
 
         const mesh = new Mesh(device);
         mesh.setPositions(flatPositions);
-        mesh.setColors(flatColors);
+        mesh.setColors32(flatColors);
         mesh.setIndices(flatIndices);
         mesh.update(PRIMITIVE_TRIANGLES);
         mesh.generateWireframe();
@@ -245,6 +251,8 @@ class MeshDebugOverlay {
 
     destroy(): void {
         this.entity?.destroy();
+        this.app.scene.layers.remove(this.layer);
+        this.camera.camera.layers = this.camera.camera.layers.filter(id => id !== this.layer.id);
     }
 }
 

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -16,7 +16,7 @@ import {
     StandardMaterial
 } from 'playcanvas';
 
-import type { MeshCollision } from './collision';
+import type { MeshCollision, TriangleSoA } from './collision';
 
 // Single-layer overlay rendered after the gaussians, three passes on a fresh
 // depth buffer:
@@ -58,38 +58,22 @@ const SURFACE_ALPHA  = 0.30;
 // Without CameraFrame, `gammaCorrectOutput` applies `pow(1/2.2)` to the
 // material output, so we feed `pow(gray, 2.2)` here and gamma-correct
 // undoes it; the framebuffer ends up storing the same raw gray value.
-const buildFlatMesh = (
-    positions: Float32Array,
-    indices: Uint32Array | Uint16Array,
-    cameraFrameEnabled: boolean
-) => {
+const buildFlatMesh = (tris: TriangleSoA, cameraFrameEnabled: boolean) => {
     const encode = (v: number) => Math.round((cameraFrameEnabled ? v : Math.pow(v, 2.2)) * 255);
     const grayX = encode(SURFACE_GRAY_X);
     const grayY = encode(SURFACE_GRAY_Y);
     const grayZ = encode(SURFACE_GRAY_Z);
     const alpha = Math.round(SURFACE_ALPHA * 255);
 
-    const numTris = Math.floor(indices.length / 3);
+    const numTris = tris.count;
     const flatPositions = new Float32Array(numTris * 9);
     const flatColors = new Uint8Array(numTris * 12);
     const flatIndices = new Uint32Array(numTris * 3);
 
     for (let i = 0; i < numTris; i++) {
-        const i0 = indices[i * 3] * 3;
-        const i1 = indices[i * 3 + 1] * 3;
-        const i2 = indices[i * 3 + 2] * 3;
-
-        const v0x = positions[i0], v0y = positions[i0 + 1], v0z = positions[i0 + 2];
-        const v1x = positions[i1], v1y = positions[i1 + 1], v1z = positions[i1 + 2];
-        const v2x = positions[i2], v2y = positions[i2 + 1], v2z = positions[i2 + 2];
-
-        const e1x = v1x - v0x, e1y = v1y - v0y, e1z = v1z - v0z;
-        const e2x = v2x - v0x, e2y = v2y - v0y, e2z = v2z - v0z;
-        const nx = e1y * e2z - e1z * e2y;
-        const ny = e1z * e2x - e1x * e2z;
-        const nz = e1x * e2y - e1y * e2x;
-
-        const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz);
+        const ax = Math.abs(tris.nx[i]);
+        const ay = Math.abs(tris.ny[i]);
+        const az = Math.abs(tris.nz[i]);
         let gray;
         if (ax > ay && ax > az) {
             gray = grayX;
@@ -100,9 +84,9 @@ const buildFlatMesh = (
         }
 
         const op = i * 9;
-        flatPositions[op]     = v0x; flatPositions[op + 1] = v0y; flatPositions[op + 2] = v0z;
-        flatPositions[op + 3] = v1x; flatPositions[op + 4] = v1y; flatPositions[op + 5] = v1z;
-        flatPositions[op + 6] = v2x; flatPositions[op + 7] = v2y; flatPositions[op + 8] = v2z;
+        flatPositions[op]     = tris.v0x[i]; flatPositions[op + 1] = tris.v0y[i]; flatPositions[op + 2] = tris.v0z[i];
+        flatPositions[op + 3] = tris.v1x[i]; flatPositions[op + 4] = tris.v1y[i]; flatPositions[op + 5] = tris.v1z[i];
+        flatPositions[op + 6] = tris.v2x[i]; flatPositions[op + 7] = tris.v2y[i]; flatPositions[op + 8] = tris.v2z[i];
 
         const oc = i * 12;
         for (let j = 0; j < 3; j++) {
@@ -153,16 +137,17 @@ class MeshDebugOverlay {
 
     private entity: Entity;
 
+    private materials: StandardMaterial[];
+
     private _enabled = false;
 
     constructor(app: AppBase, collision: MeshCollision, camera: Entity, cameraFrameEnabled: boolean) {
         this.app = app;
         this.camera = camera;
         const device = app.graphicsDevice;
-        const { positions, indices } = collision;
 
         const { flatPositions, flatColors, flatIndices } =
-            buildFlatMesh(positions, indices, cameraFrameEnabled);
+            buildFlatMesh(collision.triangles, cameraFrameEnabled);
 
         const mesh = new Mesh(device);
         mesh.setPositions(flatPositions);
@@ -262,6 +247,8 @@ class MeshDebugOverlay {
         });
         wireframeEntity.render.renderStyle = RENDERSTYLE_WIREFRAME;
 
+        this.materials = [depthMaterial, surfaceMaterial, wireframeMaterial];
+
         this.entity = new Entity('MeshCollisionDebug');
         this.entity.addChild(depthEntity);
         this.entity.addChild(surfaceEntity);
@@ -280,7 +267,13 @@ class MeshDebugOverlay {
     }
 
     destroy(): void {
+        // Entity.destroy() removes child entities and tears down their render
+        // components, which destroy the MeshInstances and decref the shared
+        // Mesh (the last decref destroys its GPU buffers). Materials are not
+        // owned by MeshInstance so destroy them explicitly here.
         this.entity?.destroy();
+        for (const m of this.materials) m.destroy();
+        this.materials.length = 0;
         this.app.scene.layers.remove(this.layer);
         this.camera.camera.layers = this.camera.camera.layers.filter(id => id !== this.layer.id);
     }

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -1,6 +1,5 @@
 import {
     type AppBase,
-    BLEND_NONE,
     BLEND_NORMAL,
     Color,
     CULLFACE_BACK,
@@ -20,24 +19,30 @@ import {
 import type { MeshCollision } from './collision';
 
 // Single-layer overlay rendered after the gaussians, three passes on a fresh
-// depth buffer, all using stock StandardMaterial:
+// depth buffer:
 //
-//   1. Surface depth pre-pass: depth test/write on, color writes off — stamps
-//      the front-most surface depth into the depth buffer.
-//   2. Surface color pass: depthFunc EQUAL, depth write off — only the
-//      front-most fragment from pass 1 survives, so a single layer of
-//      semi-transparent surface color blends onto the camera target. Tint is
-//      baked per-vertex from each triangle's face normal at construction
-//      time, so no custom shader is needed.
-//   3. Wireframe pass: black lines (RENDERSTYLE_WIREFRAME) depth-tested
-//      against the surface depth so back-facing edges are hidden.
+//   1. Surface depth pre-pass: color writes masked off, depth test/write on.
+//      Stamps the front-most surface depth into the depth buffer.
+//   2. Surface color pass: depthFunc EQUAL, depth write off, vertex-color
+//      tinted via StandardMaterial. Only the front-most fragment from pass 1
+//      survives so a single layer of semi-transparent surface color blends
+//      onto the camera target.
+//   3. Wireframe pass: opaque-looking black lines (RENDERSTYLE_WIREFRAME),
+//      depth-tested against the surface depth so back-facing edges are
+//      hidden.
+//
+// All three passes use BLEND_NORMAL so they share the layer's *transparent*
+// render action. PlayCanvas creates separate opaque and transparent render
+// actions per layer and `clearDepthBuffer` clears the depth buffer for each
+// of them — if the depth pre-pass were opaque, the transparent action would
+// wipe the depth before pass 2 and FUNC_EQUAL would always fail.
 
 const SURFACE_ALPHA = 0.3;
 
 // Build an unindexed mesh where every triangle has three unique vertices that
 // share the triangle's flat face color (tint by dominant axis of the face
-// normal, alpha baked in). Using per-triangle vertices avoids derivative
-// shimmer and gives the surface a faceted look matching the voxel overlay.
+// normal, alpha baked in). Per-triangle vertices give the surface a faceted
+// look matching the voxel overlay.
 const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Array) => {
     const numTris = Math.floor(indices.length / 3);
     const flatPositions = new Float32Array(numTris * 9);
@@ -92,14 +97,23 @@ const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Arr
     return { flatPositions, flatColors, flatIndices };
 };
 
-const makeUnlit = () => {
+// Configures a StandardMaterial that emits the per-vertex color directly. The
+// depth pre-pass and the color pass use the same configuration (so they
+// compile to identical shaders and produce bit-identical depth values for
+// FUNC_EQUAL); only their write masks and depth state differ.
+const makeSurfaceMaterial = () => {
     const m = new StandardMaterial();
     m.useLighting = false;
     m.useSkybox = false;
     m.ambient = new Color(0, 0, 0);
     m.diffuse = new Color(0, 0, 0);
     m.specular = new Color(0, 0, 0);
-    m.emissive = new Color(0, 0, 0);
+    m.emissive = new Color(1, 1, 1);
+    m.emissiveVertexColor = true;
+    m.emissiveVertexColorChannel = 'rgb';
+    m.opacityVertexColor = true;
+    m.opacityVertexColorChannel = 'a';
+    m.opacity = 1;
     return m;
 };
 
@@ -123,8 +137,6 @@ class MeshDebugOverlay {
         mesh.update(PRIMITIVE_TRIANGLES);
         mesh.generateWireframe();
 
-        // Overlay layer rendered after everything, with a fresh depth buffer.
-        // Manual sort keeps the three passes ordered by drawOrder.
         this.layer = new Layer({
             name: 'CollisionOverlay',
             clearColorBuffer: false,
@@ -135,12 +147,13 @@ class MeshDebugOverlay {
         app.scene.layers.push(this.layer);
         camera.camera.layers = [...camera.camera.layers, this.layer.id];
 
-        // Pass 1: depth pre-pass. No color writes.
-        const depthMaterial = makeUnlit();
-        depthMaterial.blendType = BLEND_NONE;
+        // Pass 1: depth pre-pass. Color writes masked off so only depth lands
+        // in the buffer.
+        const depthMaterial = makeSurfaceMaterial();
+        depthMaterial.cull = CULLFACE_BACK;
+        depthMaterial.blendType = BLEND_NORMAL;
         depthMaterial.depthTest = true;
         depthMaterial.depthWrite = true;
-        depthMaterial.cull = CULLFACE_BACK;
         depthMaterial.redWrite = false;
         depthMaterial.greenWrite = false;
         depthMaterial.blueWrite = false;
@@ -156,20 +169,15 @@ class MeshDebugOverlay {
             layers: [this.layer.id]
         });
 
-        // Pass 2: surface color, depth EQUAL. Vertex color drives both the
-        // emissive tint and the opacity, no shaders required.
-        const surfaceMaterial = makeUnlit();
-        surfaceMaterial.emissive = new Color(1, 1, 1);
-        surfaceMaterial.emissiveVertexColor = true;
-        surfaceMaterial.emissiveVertexColorChannel = 'rgb';
-        surfaceMaterial.opacityVertexColor = true;
-        surfaceMaterial.opacityVertexColorChannel = 'a';
-        surfaceMaterial.opacity = 1;
+        // Pass 2: surface color, depth EQUAL. Only the front-most fragment
+        // from pass 1 survives, so a single layer of vertex color blends onto
+        // the camera target.
+        const surfaceMaterial = makeSurfaceMaterial();
+        surfaceMaterial.cull = CULLFACE_BACK;
         surfaceMaterial.blendType = BLEND_NORMAL;
         surfaceMaterial.depthTest = true;
         surfaceMaterial.depthFunc = FUNC_EQUAL;
         surfaceMaterial.depthWrite = false;
-        surfaceMaterial.cull = CULLFACE_BACK;
         surfaceMaterial.update();
 
         const surfaceInstance = new MeshInstance(mesh, surfaceMaterial);
@@ -181,10 +189,19 @@ class MeshDebugOverlay {
             layers: [this.layer.id]
         });
 
-        // Pass 3: wireframe, opaque black, depth-tested against the surface.
-        const wireframeMaterial = makeUnlit();
+        // Pass 3: wireframe — black lines depth-tested against the surface so
+        // back-facing edges are hidden. BLEND_NORMAL with opacity = 1 looks
+        // opaque but routes through the same transparent render action as the
+        // other two passes, keeping all three under one depth clear.
+        const wireframeMaterial = new StandardMaterial();
+        wireframeMaterial.useLighting = false;
+        wireframeMaterial.useSkybox = false;
+        wireframeMaterial.ambient = new Color(0, 0, 0);
+        wireframeMaterial.diffuse = new Color(0, 0, 0);
+        wireframeMaterial.specular = new Color(0, 0, 0);
+        wireframeMaterial.emissive = new Color(0, 0, 0);
         wireframeMaterial.opacity = 1;
-        wireframeMaterial.blendType = BLEND_NONE;
+        wireframeMaterial.blendType = BLEND_NORMAL;
         wireframeMaterial.depthTest = true;
         wireframeMaterial.depthFunc = FUNC_LESSEQUAL;
         wireframeMaterial.depthWrite = false;

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -58,7 +58,11 @@ const SURFACE_ALPHA  = 0.30;
 // Without CameraFrame, `gammaCorrectOutput` applies `pow(1/2.2)` to the
 // material output, so we feed `pow(gray, 2.2)` here and gamma-correct
 // undoes it; the framebuffer ends up storing the same raw gray value.
-const buildFlatMesh = (tris: TriangleSoA, cameraFrameEnabled: boolean) => {
+// Encode the per-triangle gray + alpha into a flat Uint8 RGBA color stream
+// (one entry per unwelded vertex, three vertices per triangle). Reuses an
+// existing buffer if one is provided so colors can be re-baked when the
+// CameraFrame state toggles at runtime (e.g. XR start/end).
+const encodeFlatColors = (tris: TriangleSoA, cameraFrameEnabled: boolean, out?: Uint8Array) => {
     const encode = (v: number) => Math.round((cameraFrameEnabled ? v : Math.pow(v, 2.2)) * 255);
     const grayX = encode(SURFACE_GRAY_X);
     const grayY = encode(SURFACE_GRAY_Y);
@@ -66,9 +70,7 @@ const buildFlatMesh = (tris: TriangleSoA, cameraFrameEnabled: boolean) => {
     const alpha = Math.round(SURFACE_ALPHA * 255);
 
     const numTris = tris.count;
-    const flatPositions = new Float32Array(numTris * 9);
-    const flatColors = new Uint8Array(numTris * 12);
-    const flatIndices = new Uint32Array(numTris * 3);
+    const colors = out ?? new Uint8Array(numTris * 12);
 
     for (let i = 0; i < numTris; i++) {
         const ax = Math.abs(tris.nx[i]);
@@ -83,19 +85,30 @@ const buildFlatMesh = (tris: TriangleSoA, cameraFrameEnabled: boolean) => {
             gray = grayZ;
         }
 
+        const oc = i * 12;
+        for (let j = 0; j < 3; j++) {
+            const k = oc + j * 4;
+            colors[k]     = gray;
+            colors[k + 1] = gray;
+            colors[k + 2] = gray;
+            colors[k + 3] = alpha;
+        }
+    }
+
+    return colors;
+};
+
+const buildFlatMesh = (tris: TriangleSoA, cameraFrameEnabled: boolean) => {
+    const numTris = tris.count;
+    const flatPositions = new Float32Array(numTris * 9);
+    const flatColors = encodeFlatColors(tris, cameraFrameEnabled);
+    const flatIndices = new Uint32Array(numTris * 3);
+
+    for (let i = 0; i < numTris; i++) {
         const op = i * 9;
         flatPositions[op]     = tris.v0x[i]; flatPositions[op + 1] = tris.v0y[i]; flatPositions[op + 2] = tris.v0z[i];
         flatPositions[op + 3] = tris.v1x[i]; flatPositions[op + 4] = tris.v1y[i]; flatPositions[op + 5] = tris.v1z[i];
         flatPositions[op + 6] = tris.v2x[i]; flatPositions[op + 7] = tris.v2y[i]; flatPositions[op + 8] = tris.v2z[i];
-
-        const oc = i * 12;
-        for (let j = 0; j < 3; j++) {
-            const k = oc + j * 4;
-            flatColors[k]     = gray;
-            flatColors[k + 1] = gray;
-            flatColors[k + 2] = gray;
-            flatColors[k + 3] = alpha;
-        }
 
         const oi = i * 3;
         flatIndices[oi]     = oi;
@@ -137,6 +150,12 @@ class MeshDebugOverlay {
 
     private entity: Entity;
 
+    private mesh: Mesh;
+
+    private triangles: TriangleSoA;
+
+    private flatColors: Uint8Array;
+
     private materials: StandardMaterial[];
 
     private _enabled = false;
@@ -144,10 +163,12 @@ class MeshDebugOverlay {
     constructor(app: AppBase, collision: MeshCollision, camera: Entity, cameraFrameEnabled: boolean) {
         this.app = app;
         this.camera = camera;
+        this.triangles = collision.triangles;
         const device = app.graphicsDevice;
 
         const { flatPositions, flatColors, flatIndices } =
-            buildFlatMesh(collision.triangles, cameraFrameEnabled);
+            buildFlatMesh(this.triangles, cameraFrameEnabled);
+        this.flatColors = flatColors;
 
         const mesh = new Mesh(device);
         mesh.setPositions(flatPositions);
@@ -155,9 +176,11 @@ class MeshDebugOverlay {
         mesh.setIndices(flatIndices);
         mesh.update(PRIMITIVE_TRIANGLES);
         mesh.generateWireframe();
+        this.mesh = mesh;
 
         this.layer = new Layer({
             name: 'CollisionOverlay',
+            enabled: false,
             clearColorBuffer: false,
             clearDepthBuffer: true,
             opaqueSortMode: SORTMODE_MANUAL,
@@ -260,10 +283,27 @@ class MeshDebugOverlay {
     set enabled(value: boolean) {
         this._enabled = value;
         this.entity.enabled = value;
+        // Disable the layer too — otherwise its render actions still execute
+        // each frame and the per-layer `clearDepthBuffer` would wipe depth
+        // even when no overlay meshes are submitted.
+        this.layer.enabled = value;
     }
 
     get enabled(): boolean {
         return this._enabled;
+    }
+
+    /**
+     * Re-bake and re-upload the per-vertex colors so the overlay stays
+     * correct if CameraFrame is destroyed or recreated at runtime (the
+     * gamma path differs between the two states).
+     *
+     * @param cameraFrameEnabled - whether CameraFrame is currently active.
+     */
+    setCameraFrameEnabled(cameraFrameEnabled: boolean): void {
+        encodeFlatColors(this.triangles, cameraFrameEnabled, this.flatColors);
+        this.mesh.setColors32(this.flatColors);
+        this.mesh.update(PRIMITIVE_TRIANGLES);
     }
 
     destroy(): void {

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -37,13 +37,38 @@ import type { MeshCollision } from './collision';
 // of them — if the depth pre-pass were opaque, the transparent action would
 // wipe the depth before pass 2 and FUNC_EQUAL would always fail.
 
-const SURFACE_ALPHA = Math.round(0.3 * 255);
+// Linear gray levels picked by dominant face axis, plus the surface alpha.
+// These values are what we want the framebuffer to actually contain — pre-
+// encoding below makes that true regardless of the gamma path taken.
+const SURFACE_GRAY_X = 0.85;
+const SURFACE_GRAY_Y = 0.55;
+const SURFACE_GRAY_Z = 0.30;
+const SURFACE_ALPHA  = 0.30;
 
 // Build an unindexed mesh where every triangle has three unique vertices that
 // share the triangle's flat face color (tint by dominant axis of the face
 // normal, alpha baked in). Per-triangle vertices give the surface a faceted
 // look matching the voxel overlay.
-const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Array) => {
+//
+// `cameraFrameEnabled` controls how the per-vertex color is encoded so the
+// overlay looks identical between the WebGL (no CameraFrame) and
+// WebGPU/compute (CameraFrame) paths. With CameraFrame on, the engine's
+// `gammaCorrectOutput` is a no-op (GAMMA_NONE) and the StandardMaterial
+// output lands in the framebuffer as-is — so we feed the raw gray value.
+// Without CameraFrame, `gammaCorrectOutput` applies `pow(1/2.2)` to the
+// material output, so we feed `pow(gray, 2.2)` here and gamma-correct
+// undoes it; the framebuffer ends up storing the same raw gray value.
+const buildFlatMesh = (
+    positions: Float32Array,
+    indices: Uint32Array | Uint16Array,
+    cameraFrameEnabled: boolean
+) => {
+    const encode = (v: number) => Math.round((cameraFrameEnabled ? v : Math.pow(v, 2.2)) * 255);
+    const grayX = encode(SURFACE_GRAY_X);
+    const grayY = encode(SURFACE_GRAY_Y);
+    const grayZ = encode(SURFACE_GRAY_Z);
+    const alpha = Math.round(SURFACE_ALPHA * 255);
+
     const numTris = Math.floor(indices.length / 3);
     const flatPositions = new Float32Array(numTris * 9);
     const flatColors = new Uint8Array(numTris * 12);
@@ -67,11 +92,11 @@ const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Arr
         const ax = Math.abs(nx), ay = Math.abs(ny), az = Math.abs(nz);
         let gray;
         if (ax > ay && ax > az) {
-            gray = 217; // 0.85 * 255
+            gray = grayX;
         } else if (ay > az) {
-            gray = 140; // 0.55 * 255
+            gray = grayY;
         } else {
-            gray = 76;  // 0.30 * 255
+            gray = grayZ;
         }
 
         const op = i * 9;
@@ -85,7 +110,7 @@ const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Arr
             flatColors[k]     = gray;
             flatColors[k + 1] = gray;
             flatColors[k + 2] = gray;
-            flatColors[k + 3] = SURFACE_ALPHA;
+            flatColors[k + 3] = alpha;
         }
 
         const oi = i * 3;
@@ -105,6 +130,8 @@ const makeSurfaceMaterial = () => {
     const m = new StandardMaterial();
     m.useLighting = false;
     m.useSkybox = false;
+    m.useFog = false;
+    m.useTonemap = false;
     m.ambient = new Color(0, 0, 0);
     m.diffuse = new Color(0, 0, 0);
     m.specular = new Color(0, 0, 0);
@@ -128,13 +155,14 @@ class MeshDebugOverlay {
 
     private _enabled = false;
 
-    constructor(app: AppBase, collision: MeshCollision, camera: Entity) {
+    constructor(app: AppBase, collision: MeshCollision, camera: Entity, cameraFrameEnabled: boolean) {
         this.app = app;
         this.camera = camera;
         const device = app.graphicsDevice;
         const { positions, indices } = collision;
 
-        const { flatPositions, flatColors, flatIndices } = buildFlatMesh(positions, indices);
+        const { flatPositions, flatColors, flatIndices } =
+            buildFlatMesh(positions, indices, cameraFrameEnabled);
 
         const mesh = new Mesh(device);
         mesh.setPositions(flatPositions);
@@ -210,6 +238,8 @@ class MeshDebugOverlay {
         const wireframeMaterial = new StandardMaterial();
         wireframeMaterial.useLighting = false;
         wireframeMaterial.useSkybox = false;
+        wireframeMaterial.useFog = false;
+        wireframeMaterial.useTonemap = false;
         wireframeMaterial.ambient = new Color(0, 0, 0);
         wireframeMaterial.diffuse = new Color(0, 0, 0);
         wireframeMaterial.specular = new Color(0, 0, 0);

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -1,51 +1,320 @@
 import {
     type AppBase,
     BLEND_NONE,
-    Color,
+    BLEND_PREMULTIPLIED,
+    CULLFACE_BACK,
     CULLFACE_NONE,
     Entity,
+    FUNC_EQUAL,
+    FUNC_LESSEQUAL,
+    Layer,
     Mesh,
     MeshInstance,
     PRIMITIVE_TRIANGLES,
     RENDERSTYLE_WIREFRAME,
-    StandardMaterial
+    SEMANTIC_NORMAL,
+    SEMANTIC_POSITION,
+    ShaderMaterial,
+    SORTMODE_MANUAL
 } from 'playcanvas';
 
 import type { MeshCollision } from './collision';
 
+// Single-layer overlay rendered after the gaussian splats:
+//
+//   1. Layer clears the depth buffer (color is left untouched) so the mesh
+//      has a fresh depth context.
+//   2. Surface depth pre-pass: the collision mesh renders with color writes
+//      disabled and depth test/write on, establishing the front-most surface
+//      depth at each pixel.
+//   3. Surface color pass: the same mesh renders again with depthFunc EQUAL
+//      and depth write off, so only the front-most fragment from pass 2
+//      survives. Premultiplied alpha blends that one fragment onto the camera
+//      target — no order-dependent overdraw inside the mesh.
+//   4. Wireframe pass: black lines (RENDERSTYLE_WIREFRAME), depth-tested
+//      against the surface depth so back-facing edges are hidden.
+//
+// Per-triangle flat normals are baked into the vertex buffer (un-welded
+// vertices) to avoid derivative shimmer at triangle boundaries.
+
+const surfaceVertexGLSL = /* glsl */ `
+    attribute vec3 vertex_position;
+    attribute vec3 vertex_normal;
+    uniform mat4 matrix_model;
+    uniform mat4 matrix_viewProjection;
+    uniform mat3 matrix_normal;
+    varying vec3 vNormal;
+    void main(void) {
+        vNormal = normalize(matrix_normal * vertex_normal);
+        gl_Position = matrix_viewProjection * (matrix_model * vec4(vertex_position, 1.0));
+    }
+`;
+
+const surfaceFragmentGLSL = /* glsl */ `
+    varying vec3 vNormal;
+    void main(void) {
+        vec3 n = abs(normalize(vNormal));
+        vec3 color;
+        if (n.x > n.y && n.x > n.z) {
+            color = vec3(0.85);
+        } else if (n.y > n.z) {
+            color = vec3(0.55);
+        } else {
+            color = vec3(0.3);
+        }
+        float alpha = 0.55;
+        gl_FragColor = vec4(color * alpha, alpha);
+    }
+`;
+
+const surfaceVertexWGSL = /* wgsl */ `
+    attribute vertex_position: vec3f;
+    attribute vertex_normal: vec3f;
+    uniform matrix_model: mat4x4f;
+    uniform matrix_viewProjection: mat4x4f;
+    uniform matrix_normal: mat3x3f;
+    varying vNormal: vec3f;
+    @vertex fn vertexMain(input: VertexInput) -> VertexOutput {
+        var output: VertexOutput;
+        output.vNormal = normalize(uniform.matrix_normal * input.vertex_normal);
+        output.position = uniform.matrix_viewProjection * (uniform.matrix_model * vec4f(input.vertex_position, 1.0));
+        return output;
+    }
+`;
+
+const surfaceFragmentWGSL = /* wgsl */ `
+    varying vNormal: vec3f;
+    @fragment fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+        let n = abs(normalize(input.vNormal));
+        var color: vec3f;
+        if (n.x > n.y && n.x > n.z) {
+            color = vec3f(0.85);
+        } else if (n.y > n.z) {
+            color = vec3f(0.55);
+        } else {
+            color = vec3f(0.3);
+        }
+        let alpha = 0.55;
+        output.color = vec4f(color * alpha, alpha);
+        return output;
+    }
+`;
+
+// Position-only vertex shader for the depth pre-pass and the wireframe.
+// Includes a dummy varying so PlayCanvas emits the WGSL FragmentInput struct.
+const positionOnlyVertexGLSL = /* glsl */ `
+    attribute vec3 vertex_position;
+    uniform mat4 matrix_model;
+    uniform mat4 matrix_viewProjection;
+    varying float vDummy;
+    void main(void) {
+        vDummy = 0.0;
+        gl_Position = matrix_viewProjection * (matrix_model * vec4(vertex_position, 1.0));
+    }
+`;
+
+const positionOnlyVertexWGSL = /* wgsl */ `
+    attribute vertex_position: vec3f;
+    uniform matrix_model: mat4x4f;
+    uniform matrix_viewProjection: mat4x4f;
+    varying vDummy: f32;
+    @vertex fn vertexMain(input: VertexInput) -> VertexOutput {
+        var output: VertexOutput;
+        output.vDummy = 0.0;
+        output.position = uniform.matrix_viewProjection * (uniform.matrix_model * vec4f(input.vertex_position, 1.0));
+        return output;
+    }
+`;
+
+const constantBlackFragmentGLSL = /* glsl */ `
+    varying float vDummy;
+    void main(void) {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+`;
+
+const constantBlackFragmentWGSL = /* wgsl */ `
+    varying vDummy: f32;
+    @fragment fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+        var output: FragmentOutput;
+        output.color = vec4f(0.0, 0.0, 0.0, 1.0);
+        return output;
+    }
+`;
+
+// Build an unindexed mesh where every triangle has three unique vertices, each
+// carrying that triangle's flat face normal. This trades ~3x vertex memory for
+// stable per-fragment shading with no derivative artifacts.
+const buildFlatMesh = (positions: Float32Array, indices: Uint32Array | Uint16Array) => {
+    const numTris = Math.floor(indices.length / 3);
+    const flatPositions = new Float32Array(numTris * 9);
+    const flatNormals = new Float32Array(numTris * 9);
+    const flatIndices = new Uint32Array(numTris * 3);
+
+    for (let i = 0; i < numTris; i++) {
+        const i0 = indices[i * 3] * 3;
+        const i1 = indices[i * 3 + 1] * 3;
+        const i2 = indices[i * 3 + 2] * 3;
+
+        const v0x = positions[i0], v0y = positions[i0 + 1], v0z = positions[i0 + 2];
+        const v1x = positions[i1], v1y = positions[i1 + 1], v1z = positions[i1 + 2];
+        const v2x = positions[i2], v2y = positions[i2 + 1], v2z = positions[i2 + 2];
+
+        const e1x = v1x - v0x, e1y = v1y - v0y, e1z = v1z - v0z;
+        const e2x = v2x - v0x, e2y = v2y - v0y, e2z = v2z - v0z;
+        let nx = e1y * e2z - e1z * e2y;
+        let ny = e1z * e2x - e1x * e2z;
+        let nz = e1x * e2y - e1y * e2x;
+        const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+        if (len > 1e-10) {
+            const inv = 1 / len;
+            nx *= inv; ny *= inv; nz *= inv;
+        }
+
+        const o = i * 9;
+        flatPositions[o]     = v0x; flatPositions[o + 1] = v0y; flatPositions[o + 2] = v0z;
+        flatPositions[o + 3] = v1x; flatPositions[o + 4] = v1y; flatPositions[o + 5] = v1z;
+        flatPositions[o + 6] = v2x; flatPositions[o + 7] = v2y; flatPositions[o + 8] = v2z;
+
+        flatNormals[o]     = nx; flatNormals[o + 1] = ny; flatNormals[o + 2] = nz;
+        flatNormals[o + 3] = nx; flatNormals[o + 4] = ny; flatNormals[o + 5] = nz;
+        flatNormals[o + 6] = nx; flatNormals[o + 7] = ny; flatNormals[o + 8] = nz;
+
+        const oi = i * 3;
+        flatIndices[oi] = oi;
+        flatIndices[oi + 1] = oi + 1;
+        flatIndices[oi + 2] = oi + 2;
+    }
+
+    return { flatPositions, flatNormals, flatIndices };
+};
+
 class MeshDebugOverlay {
+    private layer: Layer;
+
     private entity: Entity;
 
     private _enabled = false;
 
-    constructor(app: AppBase, collision: MeshCollision) {
+    constructor(app: AppBase, collision: MeshCollision, camera: Entity) {
+        const device = app.graphicsDevice;
         const { positions, indices } = collision;
 
-        // Build a triangle mesh and let the engine generate a line index buffer
-        // for it. RENDERSTYLE_WIREFRAME selects that secondary index buffer.
-        const mesh = new Mesh(app.graphicsDevice);
-        mesh.setPositions(positions);
-        mesh.setIndices(indices instanceof Uint32Array ? indices : new Uint32Array(indices));
+        const { flatPositions, flatNormals, flatIndices } = buildFlatMesh(positions, indices);
+
+        const mesh = new Mesh(device);
+        mesh.setPositions(flatPositions);
+        mesh.setNormals(flatNormals);
+        mesh.setIndices(flatIndices);
         mesh.update(PRIMITIVE_TRIANGLES);
         mesh.generateWireframe();
 
-        const material = new StandardMaterial();
-        material.useLighting = false;
-        material.diffuse = new Color(0, 0, 0);
-        material.emissive = new Color(0, 0, 0);
-        material.blendType = BLEND_NONE;
-        material.depthTest = true;
-        material.depthWrite = true;
-        material.cull = CULLFACE_NONE;
-        material.update();
+        // One overlay layer rendered after everything, with a fresh depth
+        // buffer. Manual sort lets the three passes execute in drawOrder.
+        this.layer = new Layer({
+            name: 'CollisionOverlay',
+            clearColorBuffer: false,
+            clearDepthBuffer: true,
+            opaqueSortMode: SORTMODE_MANUAL,
+            transparentSortMode: SORTMODE_MANUAL
+        });
+        app.scene.layers.push(this.layer);
+        camera.camera.layers = [...camera.camera.layers, this.layer.id];
 
-        const meshInstance = new MeshInstance(mesh, material);
+        // Pass 1: depth pre-pass. No color writes, normal depth test/write.
+        const depthMaterial = new ShaderMaterial();
+        depthMaterial.cull = CULLFACE_BACK;
+        depthMaterial.blendType = BLEND_NONE;
+        depthMaterial.depthTest = true;
+        depthMaterial.depthWrite = true;
+        depthMaterial.redWrite = false;
+        depthMaterial.greenWrite = false;
+        depthMaterial.blueWrite = false;
+        depthMaterial.alphaWrite = false;
+        depthMaterial.shaderDesc = {
+            uniqueName: 'CollisionDepthPrepass',
+            vertexGLSL: positionOnlyVertexGLSL,
+            fragmentGLSL: constantBlackFragmentGLSL,
+            vertexWGSL: positionOnlyVertexWGSL,
+            fragmentWGSL: constantBlackFragmentWGSL,
+            attributes: { vertex_position: SEMANTIC_POSITION }
+        };
+        depthMaterial.update();
+
+        const depthInstance = new MeshInstance(mesh, depthMaterial);
+        depthInstance.drawOrder = 0;
+
+        const depthEntity = new Entity('CollisionDepthPrepass');
+        depthEntity.addComponent('render', {
+            meshInstances: [depthInstance],
+            layers: [this.layer.id]
+        });
+
+        // Pass 2: color pass with depth EQUAL. Only the front-most fragment
+        // from pass 1 survives, so premultiplied alpha blends a single layer
+        // of mesh color onto the camera target.
+        const surfaceMaterial = new ShaderMaterial();
+        surfaceMaterial.cull = CULLFACE_BACK;
+        surfaceMaterial.blendType = BLEND_PREMULTIPLIED;
+        surfaceMaterial.depthTest = true;
+        surfaceMaterial.depthFunc = FUNC_EQUAL;
+        surfaceMaterial.depthWrite = false;
+        surfaceMaterial.shaderDesc = {
+            uniqueName: 'CollisionSurface',
+            vertexGLSL: surfaceVertexGLSL,
+            fragmentGLSL: surfaceFragmentGLSL,
+            vertexWGSL: surfaceVertexWGSL,
+            fragmentWGSL: surfaceFragmentWGSL,
+            attributes: {
+                vertex_position: SEMANTIC_POSITION,
+                vertex_normal: SEMANTIC_NORMAL
+            }
+        };
+        surfaceMaterial.update();
+
+        const surfaceInstance = new MeshInstance(mesh, surfaceMaterial);
+        surfaceInstance.drawOrder = 1;
+
+        const surfaceEntity = new Entity('CollisionSurface');
+        surfaceEntity.addComponent('render', {
+            meshInstances: [surfaceInstance],
+            layers: [this.layer.id]
+        });
+
+        // Pass 3: wireframe — black lines depth-tested against the surface so
+        // back-facing edges are hidden. LESSEQUAL keeps front-edge lines from
+        // failing against the depth their own surface wrote.
+        const wireframeMaterial = new ShaderMaterial();
+        wireframeMaterial.cull = CULLFACE_NONE;
+        wireframeMaterial.blendType = BLEND_NONE;
+        wireframeMaterial.depthTest = true;
+        wireframeMaterial.depthFunc = FUNC_LESSEQUAL;
+        wireframeMaterial.depthWrite = false;
+        wireframeMaterial.shaderDesc = {
+            uniqueName: 'CollisionWireframeFlat',
+            vertexGLSL: positionOnlyVertexGLSL,
+            fragmentGLSL: constantBlackFragmentGLSL,
+            vertexWGSL: positionOnlyVertexWGSL,
+            fragmentWGSL: constantBlackFragmentWGSL,
+            attributes: { vertex_position: SEMANTIC_POSITION }
+        };
+        wireframeMaterial.update();
+
+        const wireframeInstance = new MeshInstance(mesh, wireframeMaterial);
+        wireframeInstance.drawOrder = 2;
+
+        const wireframeEntity = new Entity('CollisionWireframe');
+        wireframeEntity.addComponent('render', {
+            meshInstances: [wireframeInstance],
+            layers: [this.layer.id]
+        });
+        wireframeEntity.render.renderStyle = RENDERSTYLE_WIREFRAME;
 
         this.entity = new Entity('MeshCollisionDebug');
-        this.entity.addComponent('render', { meshInstances: [meshInstance] });
-        // The render component overwrites each meshInstance.renderStyle with
-        // its own value, so set it on the component after the component exists.
-        this.entity.render.renderStyle = RENDERSTYLE_WIREFRAME;
+        this.entity.addChild(depthEntity);
+        this.entity.addChild(surfaceEntity);
+        this.entity.addChild(wireframeEntity);
         this.entity.enabled = false;
         app.root.addChild(this.entity);
     }

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -1,0 +1,75 @@
+import {
+    type AppBase,
+    BLEND_NORMAL,
+    Color,
+    CULLFACE_NONE,
+    Entity,
+    Mesh,
+    MeshInstance,
+    PRIMITIVE_LINES,
+    StandardMaterial
+} from 'playcanvas';
+
+import type { MeshCollision } from './collision';
+
+class MeshDebugOverlay {
+    private entity: Entity;
+
+    private _enabled = false;
+
+    constructor(app: AppBase, collision: MeshCollision) {
+        const { positions, indices } = collision;
+        const numTris = Math.floor(indices.length / 3);
+
+        // Each triangle becomes 3 line segments (6 indices).
+        const lineIndices = new Uint32Array(numTris * 6);
+        for (let i = 0; i < numTris; i++) {
+            const i0 = indices[i * 3];
+            const i1 = indices[i * 3 + 1];
+            const i2 = indices[i * 3 + 2];
+            const o = i * 6;
+            lineIndices[o]     = i0; lineIndices[o + 1] = i1;
+            lineIndices[o + 2] = i1; lineIndices[o + 3] = i2;
+            lineIndices[o + 4] = i2; lineIndices[o + 5] = i0;
+        }
+
+        const mesh = new Mesh(app.graphicsDevice);
+        mesh.setPositions(positions);
+        mesh.setIndices(lineIndices);
+        mesh.update(PRIMITIVE_LINES);
+
+        const material = new StandardMaterial();
+        material.useLighting = false;
+        material.diffuse = new Color(0, 0, 0);
+        material.emissive = new Color(1.0, 0.25, 0.2);
+        material.opacity = 0.85;
+        material.blendType = BLEND_NORMAL;
+        material.depthTest = false;
+        material.depthWrite = false;
+        material.cull = CULLFACE_NONE;
+        material.update();
+
+        const meshInstance = new MeshInstance(mesh, material);
+        meshInstance.cull = false;
+
+        this.entity = new Entity('MeshCollisionDebug');
+        this.entity.addComponent('render', { meshInstances: [meshInstance] });
+        this.entity.enabled = false;
+        app.root.addChild(this.entity);
+    }
+
+    set enabled(value: boolean) {
+        this._enabled = value;
+        this.entity.enabled = value;
+    }
+
+    get enabled(): boolean {
+        return this._enabled;
+    }
+
+    destroy(): void {
+        this.entity?.destroy();
+    }
+}
+
+export { MeshDebugOverlay };

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,8 @@ type State = {
     hasAR: boolean;
     hasVR: boolean;
     hasCollision: boolean;
-    hasVoxelOverlay: boolean;
-    voxelOverlayEnabled: boolean;
+    hasCollisionOverlay: boolean;
+    collisionOverlayEnabled: boolean;
     isFullscreen: boolean;
     controlsHidden: boolean;
     gamingControls: boolean;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -613,16 +613,16 @@ const initUI = (global: Global) => {
         dom.flyCamera.classList.toggle('right', !value);
     });
 
-    // Voxel overlay toggle (only visible when overlay is available)
-    events.on('hasVoxelOverlay:changed', (value: boolean) => {
+    // Collision overlay toggle (only visible when overlay is available)
+    events.on('hasCollisionOverlay:changed', (value: boolean) => {
         dom.showVoxels.classList.toggle('hidden', !value);
     });
 
     dom.showVoxels.addEventListener('click', () => {
-        state.voxelOverlayEnabled = !state.voxelOverlayEnabled;
+        state.collisionOverlayEnabled = !state.collisionOverlayEnabled;
     });
 
-    events.on('voxelOverlayEnabled:changed', (value: boolean) => {
+    events.on('collisionOverlayEnabled:changed', (value: boolean) => {
         dom.showVoxels.classList.toggle('active', value);
     });
 
@@ -671,7 +671,7 @@ const initUI = (global: Global) => {
     tooltip.register(dom.fpsCamera, 'Walk Mode', 'top');
     tooltip.register(dom.reset, 'Reset Camera', 'bottom');
     tooltip.register(dom.frame, 'Frame Scene', 'bottom');
-    tooltip.register(dom.showVoxels, 'Show Voxels', 'top');
+    tooltip.register(dom.showVoxels, 'Show Collision', 'top');
     tooltip.register(dom.settings, 'Settings', 'top');
     tooltip.register(dom.info, 'Help', 'top');
     tooltip.register(dom.arMode, 'Enter AR', 'top');

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -243,7 +243,7 @@ const initUI = (global: Global) => {
         'reset', 'frame',
         'loadingText', 'loadingBar',
         'joystickBase', 'joystick',
-        'showVoxels',
+        'showCollision',
         'tooltip',
         'annotationNav', 'annotationPrev', 'annotationNext', 'annotationInfo', 'annotationNavTitle',
         'supersplatBranding'
@@ -615,15 +615,15 @@ const initUI = (global: Global) => {
 
     // Collision overlay toggle (only visible when overlay is available)
     events.on('hasCollisionOverlay:changed', (value: boolean) => {
-        dom.showVoxels.classList.toggle('hidden', !value);
+        dom.showCollision.classList.toggle('hidden', !value);
     });
 
-    dom.showVoxels.addEventListener('click', () => {
+    dom.showCollision.addEventListener('click', () => {
         state.collisionOverlayEnabled = !state.collisionOverlayEnabled;
     });
 
     events.on('collisionOverlayEnabled:changed', (value: boolean) => {
-        dom.showVoxels.classList.toggle('active', value);
+        dom.showCollision.classList.toggle('active', value);
     });
 
     dom.settings.addEventListener('click', () => {
@@ -671,7 +671,7 @@ const initUI = (global: Global) => {
     tooltip.register(dom.fpsCamera, 'Walk Mode', 'top');
     tooltip.register(dom.reset, 'Reset Camera', 'bottom');
     tooltip.register(dom.frame, 'Frame Scene', 'bottom');
-    tooltip.register(dom.showVoxels, 'Show Collision', 'top');
+    tooltip.register(dom.showCollision, 'Show Collision', 'top');
     tooltip.register(dom.settings, 'Settings', 'top');
     tooltip.register(dom.info, 'Help', 'top');
     tooltip.register(dom.arMode, 'Enter AR', 'top');

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -619,6 +619,11 @@ class Viewer {
                 camera.camera.clearColor = new Color(background.color);
             }
         }
+
+        // Mesh overlay bakes its vertex colors based on the current gamma
+        // path; reapply when CameraFrame is created/destroyed (e.g. on XR
+        // start/end) so the overlay tracks the new path.
+        this.meshOverlay?.setCameraFrameEnabled(!!this.cameraFrame);
     }
 }
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -375,7 +375,7 @@ class Viewer {
                     app.renderNextFrame = true;
                 });
             } else if (collision instanceof MeshCollision) {
-                this.meshOverlay = new MeshDebugOverlay(app, collision, camera);
+                this.meshOverlay = new MeshDebugOverlay(app, collision, camera, !!this.cameraFrame);
                 state.hasCollisionOverlay = true;
 
                 events.on('collisionOverlayEnabled:changed', (value: boolean) => {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -375,7 +375,7 @@ class Viewer {
                     app.renderNextFrame = true;
                 });
             } else if (collision instanceof MeshCollision) {
-                this.meshOverlay = new MeshDebugOverlay(app, collision);
+                this.meshOverlay = new MeshDebugOverlay(app, collision, camera);
                 state.hasCollisionOverlay = true;
 
                 events.on('collisionOverlayEnabled:changed', (value: boolean) => {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -33,9 +33,10 @@ import { Annotations } from './annotations';
 import { CameraManager } from './camera-manager';
 import { Camera } from './cameras/camera';
 import type { Collision } from './collision';
-import { VoxelCollision } from './collision';
+import { MeshCollision, VoxelCollision } from './collision';
 import { nearlyEquals } from './core/math';
 import { InputController } from './input-controller';
+import { MeshDebugOverlay } from './mesh-debug-overlay';
 import type { ExperienceSettings, PostEffectSettings } from './settings';
 import type { Config, Global } from './types';
 import { VoxelDebugOverlay } from './voxel-debug-overlay';
@@ -161,6 +162,8 @@ class Viewer {
     forceRenderNextFrame = false;
 
     voxelOverlay: VoxelDebugOverlay | null = null;
+
+    meshOverlay: MeshDebugOverlay | null = null;
 
     walkCursor: WalkCursor | null = null;
 
@@ -360,14 +363,23 @@ class Viewer {
 
             state.hasCollision = !!collision;
 
-            // Create voxel debug overlay in WebGPU only (requires voxel-specific properties)
+            // Create collision debug overlay (voxel uses a compute shader, mesh
+            // uses standard line rendering). The voxel path requires WebGPU.
             if (collision instanceof VoxelCollision && config.renderer !== 'webgl') {
                 this.voxelOverlay = new VoxelDebugOverlay(app, collision, camera);
                 this.voxelOverlay.mode = config.heatmap ? 'heatmap' : 'overlay';
-                state.hasVoxelOverlay = true;
+                state.hasCollisionOverlay = true;
 
-                events.on('voxelOverlayEnabled:changed', (value: boolean) => {
+                events.on('collisionOverlayEnabled:changed', (value: boolean) => {
                     this.voxelOverlay.enabled = value;
+                    app.renderNextFrame = true;
+                });
+            } else if (collision instanceof MeshCollision) {
+                this.meshOverlay = new MeshDebugOverlay(app, collision);
+                state.hasCollisionOverlay = true;
+
+                events.on('collisionOverlayEnabled:changed', (value: boolean) => {
+                    this.meshOverlay.enabled = value;
                     app.renderNextFrame = true;
                 });
             }

--- a/src/voxel-debug-overlay.ts
+++ b/src/voxel-debug-overlay.ts
@@ -43,11 +43,12 @@ const MAX_STEPS: u32 = 512u;
 // Target wireframe edge width in pixels
 const EDGE_PIXELS: f32 = 1.5;
 
-// Wireframe edge alpha
-const EDGE_ALPHA: f32 = 0.85;
+// Wireframe edge alpha (1.0 = pure black opaque edges, matching the mesh
+// overlay's wireframe pass).
+const EDGE_ALPHA: f32 = 0.8;
 
-// Interior fill alpha (subtle orientation tint)
-const FILL_ALPHA: f32 = 0.12;
+// Interior fill alpha (matching the mesh overlay's surface alpha).
+const FILL_ALPHA: f32 = 0.30;
 
 struct Uniforms {
     invVP: mat4x4<f32>,
@@ -156,14 +157,16 @@ fn edgeFactor(hitPos: vec3f, voxMin: vec3f, voxSize: f32, edgeWidth: f32) -> f32
     return 1.0 - smoothstep(0.0, edgeWidth, edgeDist);
 }
 
-// Shade a voxel hit, returning premultiplied RGBA
-fn shadeVoxelHit(hitPos: vec3f, voxMin: vec3f, voxelRes: f32, ro: vec3f, isFullBlock: bool) -> vec4f {
+// Shade a voxel hit, returning premultiplied RGBA. Uses the same face-axis
+// grayscale palette as the mesh collision overlay (0.85 / 0.55 / 0.30 by
+// dominant axis), with pure black at face edges to mimic that overlay's
+// wireframe pass.
+fn shadeVoxelHit(hitPos: vec3f, voxMin: vec3f, voxelRes: f32, ro: vec3f) -> vec4f {
     let dist = length(hitPos - ro);
     let pixelWorld = 2.0 * dist / (f32(uniforms.screenHeight) * uniforms.projScaleY);
     let ew = clamp(EDGE_PIXELS * pixelWorld / voxelRes, 0.01, 0.5);
 
     let ef = edgeFactor(hitPos, voxMin, voxelRes, ew);
-    let distFade = clamp(1.0 - dist * 0.01, 0.2, 1.0);
 
     let local = (hitPos - voxMin) / voxelRes;
     let fx = min(local.x, 1.0 - local.x);
@@ -178,19 +181,17 @@ fn shadeVoxelHit(hitPos: vec3f, voxMin: vec3f, voxelRes: f32, ro: vec3f, isFullB
     }
 
     var baseColor: vec3f;
-    if (isFullBlock) {
-        if (faceAxis == 0u) { baseColor = vec3f(1.0, 0.25, 0.2); }
-        else if (faceAxis == 1u) { baseColor = vec3f(0.8, 0.15, 0.1); }
-        else { baseColor = vec3f(0.55, 0.08, 0.05); }
-    } else {
-        if (faceAxis == 0u) { baseColor = vec3f(0.7, 0.7, 0.72); }
-        else if (faceAxis == 1u) { baseColor = vec3f(0.5, 0.5, 0.52); }
-        else { baseColor = vec3f(0.33, 0.33, 0.35); }
-    }
+    if (faceAxis == 0u) { baseColor = vec3f(0.85); }
+    else if (faceAxis == 1u) { baseColor = vec3f(0.55); }
+    else { baseColor = vec3f(0.30); }
 
-    let alpha = mix(FILL_ALPHA, EDGE_ALPHA, ef) * distFade;
+    // Mix the surface base color toward black as the edge factor approaches 1
+    // and ramp alpha from FILL_ALPHA up to EDGE_ALPHA so face edges read as
+    // opaque black lines while the interior stays at the surface tint.
+    let color = mix(baseColor, vec3f(0.0), ef);
+    let alpha = mix(FILL_ALPHA, EDGE_ALPHA, ef);
 
-    return vec4f(mix(baseColor, vec3f(0.0), alpha) * alpha, alpha);
+    return vec4f(color * alpha, alpha);
 }
 
 // Blue (0) -> Cyan (0.25) -> Green (0.5) -> Yellow (0.75) -> Red (1.0)
@@ -387,8 +388,7 @@ fn main(@builtin(global_invocation_id) gid: vec3u) {
                             let voxMin = blockOrigin + vec3f(f32(vx), f32(vy), f32(vz)) * voxelRes;
                             let vHit = intersectAABB(ro, invDir, voxMin, voxMin + vec3f(voxelRes));
                             let hitPos = ro + rd * max(vHit.x, 0.0);
-                            let isFullBlock = select(blockResult == 1u, blockResult == 0u, inv);
-                            let result = shadeVoxelHit(hitPos, voxMin, voxelRes, ro, isFullBlock);
+                            let result = shadeVoxelHit(hitPos, voxMin, voxelRes, ro);
                             textureStore(outputTexture, vec2i(px, py), result);
                         } else {
                             let effort = f32(totalWork) / 256.0;


### PR DESCRIPTION
## Summary

Adds a `MeshDebugOverlay` that visualizes the loaded GLB collision mesh as a faceted, semi-transparent grayscale surface with a black wireframe on top. Toggled by the same V-key / control button that previously toggled the voxel overlay — voxel and mesh collisions are mutually exclusive, so the existing state is renamed `voxelOverlay*` → `collisionOverlay*` and now drives whichever overlay matches the loaded collision type. The voxel overlay is unchanged.

Built with stock `StandardMaterial` only — no custom shaders. Per-face gray tint is baked into a `Uint8Array` vertex-color attribute at construction (face-axis: `0.85` / `0.55` / `0.30`), so the surface looks faceted matching the voxel overlay style.

## Rendering

A dedicated overlay layer renders after the gaussian splats with a fresh depth buffer. Three passes share the layer's transparent render action so the layer's depth clear only fires once:

1. **Depth pre-pass** — color writes masked off; stamps the front-most surface depth into the depth buffer.
2. **Surface color pass** — `depthFunc EQUAL`, `depthWrite=false`. Only the front-most fragment from pass 1 survives, so a single layer of semi-transparent vertex-color blends onto the camera target — internal triangle order doesn't matter.
3. **Wireframe** — black lines (`RENDERSTYLE_WIREFRAME`), `depthFunc LESSEQUAL`, depth-tested against the surface so back-facing edges are hidden.

### Subtleties worth knowing

- **All three passes use `BLEND_NORMAL`.** PlayCanvas creates separate opaque and transparent render actions per layer and `clearDepthBuffer` fires for each. If the depth pre-pass were opaque, the transparent action would wipe the depth before the color pass and `FUNC_EQUAL` would always fail.
- **Pre-pass and color pass share an identical material configuration** (`makeSurfaceMaterial()` plus `redWrite/...` masks for the pre-pass) so they compile to the same shader and produce bit-identical depth values — required for `FUNC_EQUAL` to match in WebGL2 too, not just WebGPU.
- **`depthBias = 1` / `slopeDepthBias = 1`** on both triangle passes. PlayCanvas only enables `POLYGON_OFFSET_FILL`, so the bias applies to the surface but not the wireframe — keeps the wireframe reliably ahead of the surface depth without flicker, while the EQUAL match between pre-pass and color pass is preserved (both biased identically).
- **Per-triangle vertex unwelding.** `buildFlatMesh` creates 3 unique vertices per triangle so each triangle carries its own flat color and the wireframe edges generated by `mesh.generateWireframe()` are unambiguous. ~3x vertex memory; vertex colors stored as `Uint8Array` (`setColors32`) to keep the upload small.

## Other changes

- `MeshCollision` now exposes `positions` and `indices` as `readonly` public fields so the overlay can build its surface mesh from the same triangles that drive collision queries.
- DOM button id renamed `showVoxels` → `showCollision`. Icon (`#voxelIcon`) and CSS unchanged.

## Test plan

- [ ] Load a scene with a GLB collision (`?collision=…glb`) under both WebGPU (`?webgpu=`) and WebGL backends, toggle the overlay with V and the control button.
- [ ] Verify surface fill is visible (~30% alpha grayscale, faceted by face axis) and wireframe edges are crisp / non-flickery from multiple camera angles, including glancing angles.
- [ ] Verify back-facing edges are hidden behind the front surface.
- [ ] Load a scene with a voxel collision (`?collision=…voxel`) and confirm the voxel overlay still works and uses the same V key / button.
- [ ] Confirm a scene with no collision hides the button entirely.