### PR TITLE
Add smooth target navigation for fly and orbit modes

### DIFF
--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -23,8 +23,8 @@ class Annotations {
 
         const updateVisibility = () => {
             const firstPersonGamingControls = (
-                (state.cameraMode === 'walk' && state.gamingControls) ||
-                (state.cameraMode === 'fly' && state.inputMode === 'desktop' && state.gamingControls)
+                (state.cameraMode === 'walk' || state.cameraMode === 'fly') &&
+                state.gamingControls
             );
             const hidden = state.controlsHidden || firstPersonGamingControls;
             parentDom.style.display = hidden ? 'none' : 'block';
@@ -36,7 +36,6 @@ class Annotations {
 
         global.events.on('controlsHidden:changed', updateVisibility);
         global.events.on('cameraMode:changed', updateVisibility);
-        global.events.on('inputMode:changed', updateVisibility);
         global.events.on('gamingControls:changed', updateVisibility);
         updateVisibility();
 

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -22,7 +22,11 @@ class Annotations {
         const { state } = global;
 
         const updateVisibility = () => {
-            const hidden = state.controlsHidden || (state.cameraMode === 'walk' && state.gamingControls);
+            const firstPersonGamingControls = (
+                (state.cameraMode === 'walk' && state.gamingControls) ||
+                (state.cameraMode === 'fly' && state.inputMode === 'desktop' && state.gamingControls)
+            );
+            const hidden = state.controlsHidden || firstPersonGamingControls;
             parentDom.style.display = hidden ? 'none' : 'block';
             Annotation.opacity = hidden ? 0.0 : 1.0;
             if (this.annotations.length > 0) {

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -36,6 +36,7 @@ class Annotations {
 
         global.events.on('controlsHidden:changed', updateVisibility);
         global.events.on('cameraMode:changed', updateVisibility);
+        global.events.on('inputMode:changed', updateVisibility);
         global.events.on('gamingControls:changed', updateVisibility);
         updateVisibility();
 

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -163,7 +163,7 @@ class CameraManager {
         };
 
         // handle input events
-        events.on('inputEvent', (eventName, event) => {
+        events.on('inputEvent', (eventName) => {
             switch (eventName) {
                 case 'frame':
                     events.fire('orbitTarget:clear');
@@ -224,8 +224,6 @@ class CameraManager {
                 case 'interrupt':
                     if (state.cameraMode === 'anim') {
                         state.cameraMode = fromMode;
-                    } else if (state.cameraMode === 'fly') {
-                        flySource.cancelFly();
                     }
                     break;
             }

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -168,6 +168,9 @@ class CameraManager {
                         events.fire('walkTarget:clear');
                         startTransition();
                         controllers.walk.resetToSpawn(target);
+                    } else if (state.cameraMode === 'fly') {
+                        startTransition();
+                        controllers.fly.resetToSpawn(target);
                     } else {
                         state.cameraMode = 'orbit';
                         controllers.orbit.goto(resetCamera);

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -163,9 +163,16 @@ class CameraManager {
                     startTransition();
                     break;
                 case 'reset':
-                    state.cameraMode = 'orbit';
-                    controllers.orbit.goto(resetCamera);
-                    startTransition();
+                    if (state.cameraMode === 'walk') {
+                        walkSource.cancelWalk();
+                        events.fire('walkTarget:clear');
+                        startTransition();
+                        controllers.walk.resetToSpawn(target);
+                    } else {
+                        state.cameraMode = 'orbit';
+                        controllers.orbit.goto(resetCamera);
+                        startTransition();
+                    }
                     break;
                 case 'playPause':
                     if (state.hasAnimation) {

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -144,7 +144,7 @@ class CameraManager {
             if (state.cameraMode === 'walk') {
                 walkSource.update(dt, this.camera.position, this.camera.angles, frame);
             } else if (state.cameraMode === 'fly') {
-                flySource.update(dt, this.camera.position, this.camera.angles, frame);
+                flySource.update(dt, this.camera.position, this.camera.angles, this.camera.fov, frame);
             }
 
             controller.update(dt, frame, target);

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -8,6 +8,7 @@ import { createRotateTrack } from './animation/create-rotate-track';
 import { AnimController } from './cameras/anim-controller';
 import { Camera, type CameraFrame, type CameraController } from './cameras/camera';
 import { FlyController } from './cameras/fly-controller';
+import { FlySource } from './cameras/fly-source';
 import { OrbitController } from './cameras/orbit-controller';
 import { WalkController } from './cameras/walk-controller';
 import { WalkSource } from './cameras/walk-source';
@@ -91,6 +92,11 @@ class CameraManager {
             events.fire('walkComplete');
         };
 
+        const flySource = new FlySource();
+        flySource.onComplete = () => {
+            events.fire('flyComplete');
+        };
+
         const getController = (cameraMode: CameraMode): CameraController => {
             return controllers[cameraMode] as CameraController;
         };
@@ -137,6 +143,8 @@ class CameraManager {
 
             if (state.cameraMode === 'walk') {
                 walkSource.update(dt, this.camera.position, this.camera.angles, frame);
+            } else if (state.cameraMode === 'fly') {
+                flySource.update(dt, this.camera.position, this.camera.angles, frame);
             }
 
             controller.update(dt, frame, target);
@@ -158,6 +166,7 @@ class CameraManager {
         events.on('inputEvent', (eventName, event) => {
             switch (eventName) {
                 case 'frame':
+                    events.fire('orbitTarget:clear');
                     state.cameraMode = 'orbit';
                     controllers.orbit.goto(frameCamera);
                     startTransition();
@@ -169,9 +178,11 @@ class CameraManager {
                         startTransition();
                         controllers.walk.resetToSpawn(target);
                     } else if (state.cameraMode === 'fly') {
+                        flySource.cancelFly();
                         startTransition();
                         controllers.fly.resetToSpawn(target);
                     } else {
+                        events.fire('orbitTarget:clear');
                         state.cameraMode = 'orbit';
                         controllers.orbit.goto(resetCamera);
                         startTransition();
@@ -213,6 +224,8 @@ class CameraManager {
                 case 'interrupt':
                     if (state.cameraMode === 'anim') {
                         state.cameraMode = fromMode;
+                    } else if (state.cameraMode === 'fly') {
+                        flySource.cancelFly();
                     }
                     break;
             }
@@ -222,6 +235,8 @@ class CameraManager {
         events.on('cameraMode:changed', (value, prev) => {
             if (prev === 'walk') {
                 walkSource.cancelWalk();
+            } else if (prev === 'fly') {
+                flySource.cancelFly();
             }
 
             // snapshot the current pose before any controller mutation
@@ -262,6 +277,8 @@ class CameraManager {
         });
 
         events.on('annotation.activate', (annotation: Annotation) => {
+            events.fire('orbitTarget:clear');
+
             // switch to orbit camera on pick
             state.cameraMode = 'orbit';
 
@@ -294,6 +311,24 @@ class CameraManager {
 
         events.on('walkComplete', () => {
             events.fire('walkTarget:clear');
+        });
+
+        // click/tap-to-fly: start auto-flying toward a picked 3D position
+        events.on('flyTo', (position: Vec3, normal: Vec3) => {
+            if (state.cameraMode === 'fly') {
+                flySource.flyTo(position);
+                events.fire('flyTarget:set', position, normal);
+            }
+        });
+
+        // cancel any active auto-flight
+        events.on('flyCancel', () => {
+            flySource.cancelFly();
+            events.fire('flyTarget:clear');
+        });
+
+        events.on('flyComplete', () => {
+            events.fire('flyTarget:clear');
         });
     }
 }

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -123,6 +123,7 @@ class CameraManager {
         // transition state
         const transitionSpeed = 1.0;
         let transitionTimer = 1;
+        let clearOrbitTargetOnTransitionEnd = false;
 
         // start a new camera transition from the current pose
         const startTransition = () => {
@@ -137,6 +138,7 @@ class CameraManager {
             const dt = state.cameraMode === 'anim' && state.animationPaused ? 0 : deltaTime;
 
             // update transition timer
+            const prevTransitionTimer = transitionTimer;
             transitionTimer = Math.min(1, transitionTimer + deltaTime * transitionSpeed);
 
             const controller = getController(state.cameraMode);
@@ -159,6 +161,11 @@ class CameraManager {
             // update animation timeline
             if (state.cameraMode === 'anim') {
                 state.animationTime = controllers.anim.animState.cursor.value;
+            }
+
+            if (clearOrbitTargetOnTransitionEnd && prevTransitionTimer < 1 && transitionTimer === 1) {
+                clearOrbitTargetOnTransitionEnd = false;
+                events.fire('orbitTarget:clear');
             }
         };
 
@@ -272,6 +279,7 @@ class CameraManager {
 
             controllers.orbit.goto(tmpCamera);
             startTransition();
+            clearOrbitTargetOnTransitionEnd = true;
         });
 
         events.on('annotation.activate', (annotation: Annotation) => {

--- a/src/cameras/camera-utils.ts
+++ b/src/cameras/camera-utils.ts
@@ -1,0 +1,135 @@
+import { math, Quat, Vec3 } from 'playcanvas';
+
+import { damp } from '../core/math';
+
+const rotation = new Quat();
+
+/**
+ * Apply a CameraFrame rotate delta to camera Euler angles.
+ *
+ * CameraFrame rotate uses [yaw, pitch, roll]-style input deltas, while camera
+ * angles are stored as [pitch, yaw, roll].
+ *
+ * @param angles - Camera Euler angles to mutate.
+ * @param rotate - Frame rotate delta.
+ * @param minPitch - Minimum pitch angle in degrees.
+ * @param maxPitch - Maximum pitch angle in degrees.
+ * @returns The mutated angles.
+ */
+const applyFrameRotation = (
+    angles: Vec3,
+    rotate: readonly number[],
+    minPitch = -90,
+    maxPitch = 90
+) => {
+    angles.x -= rotate[1];
+    angles.y -= rotate[0];
+    angles.z = 0;
+    angles.x = math.clamp(angles.x, minPitch, maxPitch);
+    return angles;
+};
+
+/**
+ * Calculate camera-relative basis vectors from Euler angles.
+ *
+ * @param angles - Camera Euler angles in degrees.
+ * @param forward - Receives the forward vector.
+ * @param right - Receives the right vector.
+ * @param up - Receives the up vector.
+ */
+const setCameraBasis = (angles: Vec3, forward: Vec3, right: Vec3, up: Vec3) => {
+    rotation.setFromEulerAngles(angles);
+    rotation.transformVector(Vec3.FORWARD, forward);
+    rotation.transformVector(Vec3.RIGHT, right);
+    rotation.transformVector(Vec3.UP, up);
+};
+
+/**
+ * Calculate a camera forward vector from Euler angles.
+ *
+ * @param angles - Camera Euler angles in degrees.
+ * @param forward - Receives the forward vector.
+ */
+const setCameraForward = (angles: Vec3, forward: Vec3) => {
+    rotation.setFromEulerAngles(angles);
+    rotation.transformVector(Vec3.FORWARD, forward);
+};
+
+/**
+ * Calculate yaw-only movement basis vectors.
+ *
+ * @param yaw - Camera yaw angle in degrees.
+ * @param forward - Receives the horizontal forward vector.
+ * @param right - Receives the horizontal right vector.
+ */
+const setYawBasis = (yaw: number, forward: Vec3, right: Vec3) => {
+    rotation.setFromEulerAngles(0, yaw, 0);
+    rotation.transformVector(Vec3.FORWARD, forward);
+    rotation.transformVector(Vec3.RIGHT, right);
+};
+
+/**
+ * Build a world-space offset from local movement along camera basis vectors.
+ *
+ * @param out - Receives the world-space offset.
+ * @param x - Local right movement.
+ * @param y - Local up movement.
+ * @param z - Local forward movement.
+ * @param forward - Forward basis vector.
+ * @param right - Right basis vector.
+ * @param up - Up basis vector.
+ * @returns The mutated output vector.
+ */
+const setBasisOffset = (
+    out: Vec3,
+    x: number,
+    y: number,
+    z: number,
+    forward: Vec3,
+    right: Vec3,
+    up: Vec3
+) => {
+    out.set(
+        right.x * x + up.x * y + forward.x * z,
+        right.y * x + up.y * y + forward.y * z,
+        right.z * x + up.z * y + forward.z * z
+    );
+    return out;
+};
+
+/**
+ * Interpolate Euler angles using shortest-path angle interpolation.
+ *
+ * @param result - Receives the interpolated angles.
+ * @param a - Start angles.
+ * @param b - End angles.
+ * @param t - Interpolation factor.
+ * @returns The mutated result.
+ */
+const lerpAngles = (result: Vec3, a: Vec3, b: Vec3, t: number) => {
+    result.x = math.lerpAngle(a.x, b.x, t) % 360;
+    result.y = math.lerpAngle(a.y, b.y, t) % 360;
+    result.z = math.lerpAngle(a.z, b.z, t) % 360;
+    return result;
+};
+
+/**
+ * Convert a damping value to a frame-rate-independent interpolation alpha.
+ *
+ * @param damping - Damping factor.
+ * @param dt - Delta time in seconds.
+ * @returns Interpolation alpha for this frame.
+ */
+const dampAlpha = (damping: number, dt: number) => {
+    return dt > 0 ? damp(damping, dt) : 0;
+};
+
+export {
+    applyFrameRotation,
+    dampAlpha,
+    lerpAngles,
+    setBasisOffset,
+    setCameraBasis,
+    setCameraForward,
+    setYawBasis
+};

--- a/src/cameras/fly-controller.ts
+++ b/src/cameras/fly-controller.ts
@@ -1,7 +1,7 @@
 import {
-    FlyController as FlyControllerPC,
-    Pose,
-    Vec2
+    math,
+    Quat,
+    Vec3
 } from 'playcanvas';
 
 import type { Collision, PushOut } from '../collision';
@@ -10,69 +10,253 @@ import type { CameraFrame, Camera, CameraController } from './camera';
 /** Radius of the camera collision sphere (meters) */
 const CAMERA_RADIUS = 0.2;
 
-const p = new Pose();
+/** Extra resolve passes above the collider's internal iteration for tight corners */
+const MAX_COLLISION_PASSES = 4;
+
+/** Small clearance that keeps the camera from resting exactly on a voxel face */
+const COLLISION_SKIN = 1e-3;
+
+/** Maximum surface planes to slide along in a single frame */
+const MAX_SLIDE_ITERATIONS = 3;
+
+const MIN_MOVE_SQ = 1e-10;
+
+const v = new Vec3();
+const remainingMove = new Vec3();
+const forward = new Vec3();
+const right = new Vec3();
+const up = new Vec3();
+const offset = new Vec3();
+const collisionPush = new Vec3();
+const sweepDir = new Vec3();
+const sweepNormal = new Vec3();
+const rotation = new Quat();
 
 /** Pre-allocated push-out vector for sphere collision */
 const pushOut: PushOut = { x: 0, y: 0, z: 0 };
 
 class FlyController implements CameraController {
-    controller: FlyControllerPC;
-
     fov = 90;
 
     /** Optional collision for sphere collision with sliding */
     collision: Collision | null = null;
 
-    constructor() {
-        this.controller = new FlyControllerPC();
-        this.controller.pitchRange = new Vec2(-90, 90);
-        this.controller.rotateDamping = 0.97;
-        this.controller.moveDamping = 0.97;
-    }
+    private _position = new Vec3();
+
+    private _angles = new Vec3();
+
+    private _distance = 1;
+
+    private _spawnPosition = new Vec3();
+
+    private _spawnAngles = new Vec3();
+
+    private _spawnDistance = 1;
+
+    private _lastClearPosition = new Vec3();
+
+    private _hasLastClearPosition = false;
+
+    private _hasSpawn = false;
 
     onEnter(camera: Camera): void {
-        p.position.copy(camera.position);
-        p.angles.copy(camera.angles);
-        p.distance = camera.distance;
-        this.controller.attach(p, false);
+        this.goto(camera);
+        this._resolveCurrentPosition();
+        this._storeSpawn();
     }
 
     update(deltaTime: number, inputFrame: CameraFrame, camera: Camera) {
-        const pose = this.controller.update(inputFrame, deltaTime);
+        const { move, rotate } = inputFrame.read();
 
-        camera.angles.copy(pose.angles);
-        camera.distance = pose.distance;
+        this._angles.add(v.set(-rotate[1], -rotate[0], 0));
+        this._angles.x = math.clamp(this._angles.x, -90, 90);
 
-        if (this.collision) {
-            // Resolve collision on _targetPose first. The engine's update() already
-            // applied input to _targetPose and lerped _pose toward it. By correcting
-            // _targetPose now, we ensure next frame's lerp interpolates toward a safe
-            // position, preventing the camera from overshooting into the wall.
-            const target = (this.controller as any)._targetPose;
+        this._step(move);
 
-            if (this.collision.querySphere(target.position.x, target.position.y, target.position.z, CAMERA_RADIUS, pushOut)) {
-                target.position.x += pushOut.x;
-                target.position.y += pushOut.y;
-                target.position.z += pushOut.z;
-            }
-
-            if (this.collision.querySphere(pose.position.x, pose.position.y, pose.position.z, CAMERA_RADIUS, pushOut)) {
-                pose.position.x += pushOut.x;
-                pose.position.y += pushOut.y;
-                pose.position.z += pushOut.z;
-            }
-        }
-
-        camera.position.copy(pose.position);
+        camera.position.copy(this._position);
+        camera.angles.set(this._angles.x, this._angles.y, 0);
+        camera.distance = this._distance;
         camera.fov = this.fov;
     }
 
-    onExit(camera: Camera): void {
+    onExit(_camera: Camera): void {
 
     }
 
-    goto(pose: Pose) {
-        this.controller.attach(pose, true);
+    goto(camera: Camera) {
+        this._position.copy(camera.position);
+        this._angles.set(camera.angles.x, camera.angles.y, 0);
+        this._distance = camera.distance;
+        this._setLastClearPosition(this._position);
+    }
+
+    resetToSpawn(camera: Camera): boolean {
+        if (!this._hasSpawn) {
+            return false;
+        }
+
+        this._position.copy(this._spawnPosition);
+        this._angles.copy(this._spawnAngles);
+        this._distance = this._spawnDistance;
+        this._setLastClearPosition(this._position);
+
+        camera.position.copy(this._position);
+        camera.angles.copy(this._angles);
+        camera.distance = this._distance;
+        camera.fov = this.fov;
+
+        return true;
+    }
+
+    private _storeSpawn() {
+        this._spawnPosition.copy(this._position);
+        this._spawnAngles.copy(this._angles);
+        this._spawnDistance = this._distance;
+        this._hasSpawn = true;
+    }
+
+    private _step(move: number[]) {
+        rotation.setFromEulerAngles(this._angles);
+        rotation.transformVector(Vec3.FORWARD, forward);
+        rotation.transformVector(Vec3.RIGHT, right);
+        rotation.transformVector(Vec3.UP, up);
+
+        offset.set(0, 0, 0);
+        offset.add(forward.mulScalar(move[2]));
+        offset.add(right.mulScalar(move[0]));
+        offset.add(up.mulScalar(move[1]));
+
+        if (this.collision) {
+            this._moveWithCollision(offset);
+        } else {
+            this._position.add(offset);
+        }
+    }
+
+    private _moveWithCollision(move: Vec3) {
+        remainingMove.copy(move);
+
+        if (this._isMoveComplete(remainingMove)) {
+            this._resolveCurrentPosition();
+            return;
+        }
+
+        for (let i = 0; i < MAX_SLIDE_ITERATIONS; i++) {
+            if (this._isMoveComplete(remainingMove)) {
+                break;
+            }
+
+            if (!this._moveAndSlide(remainingMove)) {
+                break;
+            }
+        }
+    }
+
+    private _moveAndSlide(move: Vec3): boolean {
+        const moveSq = move.x * move.x + move.y * move.y + move.z * move.z;
+        const distance = Math.sqrt(moveSq);
+        sweepDir.copy(move).mulScalar(1 / distance);
+
+        const hit = this.collision!.queryRay(
+            this._position.x, this._position.y, this._position.z,
+            sweepDir.x, sweepDir.y, sweepDir.z,
+            distance + CAMERA_RADIUS + COLLISION_SKIN
+        );
+
+        if (!hit) {
+            this._position.add(move);
+            this._resolveCurrentPosition();
+            return false;
+        }
+
+        const hx = hit.x - this._position.x;
+        const hy = hit.y - this._position.y;
+        const hz = hit.z - this._position.z;
+        const hitDistance = Math.max(0, hx * sweepDir.x + hy * sweepDir.y + hz * sweepDir.z);
+        const travel = math.clamp(hitDistance - CAMERA_RADIUS - COLLISION_SKIN, 0, distance);
+
+        this._position.add(v.copy(sweepDir).mulScalar(travel));
+        this._resolveCurrentPosition();
+
+        const surfaceNormal = this.collision!.querySurfaceNormal(
+            hit.x, hit.y, hit.z,
+            sweepDir.x, sweepDir.y, sweepDir.z
+        );
+        sweepNormal.set(surfaceNormal.nx, surfaceNormal.ny, surfaceNormal.nz);
+
+        move.add(v.copy(sweepDir).mulScalar(-travel));
+        this._clipMove(move, sweepNormal);
+
+        return true;
+    }
+
+    private _resolveCurrentPosition() {
+        if (!this.collision) {
+            this._setLastClearPosition(this._position);
+            return;
+        }
+
+        this._resolveSphere(this._position, collisionPush);
+        if (!this._isSphereClear(this._position) && this._hasLastClearPosition) {
+            this._position.copy(this._lastClearPosition);
+        }
+
+        if (this._isSphereClear(this._position)) {
+            this._setLastClearPosition(this._position);
+        }
+    }
+
+    private _resolveSphere(position: Vec3, push: Vec3): boolean {
+        let collided = false;
+        push.set(0, 0, 0);
+
+        for (let i = 0; i < MAX_COLLISION_PASSES; i++) {
+            if (!this.collision!.querySphere(position.x, position.y, position.z, CAMERA_RADIUS, pushOut)) {
+                break;
+            }
+
+            position.x += pushOut.x;
+            position.y += pushOut.y;
+            position.z += pushOut.z;
+            push.x += pushOut.x;
+            push.y += pushOut.y;
+            push.z += pushOut.z;
+            collided = true;
+        }
+
+        return collided;
+    }
+
+    private _clipMove(move: Vec3, push: Vec3) {
+        const normalSq = push.x * push.x + push.y * push.y + push.z * push.z;
+        if (normalSq <= MIN_MOVE_SQ) {
+            return;
+        }
+
+        const invPushLen = 1 / Math.sqrt(normalSq);
+        const nx = push.x * invPushLen;
+        const ny = push.y * invPushLen;
+        const nz = push.z * invPushLen;
+        const dot = move.x * nx + move.y * ny + move.z * nz;
+
+        if (dot < 0) {
+            move.x -= dot * nx;
+            move.y -= dot * ny;
+            move.z -= dot * nz;
+        }
+    }
+
+    private _isMoveComplete(move: Vec3): boolean {
+        return move.x * move.x + move.y * move.y + move.z * move.z <= MIN_MOVE_SQ;
+    }
+
+    private _isSphereClear(position: Vec3): boolean {
+        return !this.collision!.querySphere(position.x, position.y, position.z, CAMERA_RADIUS, pushOut);
+    }
+
+    private _setLastClearPosition(position: Vec3) {
+        this._lastClearPosition.copy(position);
+        this._hasLastClearPosition = !this.collision || this._isSphereClear(position);
     }
 }
 

--- a/src/cameras/fly-controller.ts
+++ b/src/cameras/fly-controller.ts
@@ -1,45 +1,20 @@
-import {
-    math,
-    Quat,
-    Vec3
-} from 'playcanvas';
+import { Vec3 } from 'playcanvas';
 
-import type { Collision, PushOut } from '../collision';
+import type { Collision } from '../collision';
 import type { CameraFrame, Camera, CameraController } from './camera';
+import { applyFrameRotation, setBasisOffset, setCameraBasis } from './camera-utils';
+import { SphereMover } from './sphere-mover';
 
 /** Radius of the camera collision sphere (meters) */
 const CAMERA_RADIUS = 0.2;
 
-/** Extra resolve passes above the collider's internal iteration for tight corners */
-const MAX_COLLISION_PASSES = 4;
-
-/** Small clearance that keeps the camera from resting exactly on a voxel face */
-const COLLISION_SKIN = 1e-3;
-
-/** Maximum surface planes to slide along in a single frame */
-const MAX_SLIDE_ITERATIONS = 3;
-
-const MIN_MOVE_SQ = 1e-10;
-
-const v = new Vec3();
-const remainingMove = new Vec3();
 const forward = new Vec3();
 const right = new Vec3();
 const up = new Vec3();
 const offset = new Vec3();
-const collisionPush = new Vec3();
-const sweepDir = new Vec3();
-const sweepNormal = new Vec3();
-const rotation = new Quat();
-
-/** Pre-allocated push-out vector for sphere collision */
-const pushOut: PushOut = { x: 0, y: 0, z: 0 };
 
 class FlyController implements CameraController {
     fov = 90;
-
-    /** Optional collision for sphere collision with sliding */
-    collision: Collision | null = null;
 
     private _position = new Vec3();
 
@@ -53,23 +28,30 @@ class FlyController implements CameraController {
 
     private _spawnDistance = 1;
 
-    private _lastClearPosition = new Vec3();
+    private _mover = new SphereMover(CAMERA_RADIUS);
 
-    private _hasLastClearPosition = false;
+    /** Optional collision for sphere collision with sliding */
+    set collision(value: Collision | null) {
+        this._mover.collision = value;
+        this._mover.reset(this._position);
+    }
+
+    get collision(): Collision | null {
+        return this._mover.collision;
+    }
 
     private _hasSpawn = false;
 
     onEnter(camera: Camera): void {
         this.goto(camera);
-        this._resolveCurrentPosition();
+        this._mover.resolve(this._position);
         this._storeSpawn();
     }
 
     update(deltaTime: number, inputFrame: CameraFrame, camera: Camera) {
         const { move, rotate } = inputFrame.read();
 
-        this._angles.add(v.set(-rotate[1], -rotate[0], 0));
-        this._angles.x = math.clamp(this._angles.x, -90, 90);
+        applyFrameRotation(this._angles, rotate);
 
         this._step(move);
 
@@ -87,7 +69,7 @@ class FlyController implements CameraController {
         this._position.copy(camera.position);
         this._angles.set(camera.angles.x, camera.angles.y, 0);
         this._distance = camera.distance;
-        this._setLastClearPosition(this._position);
+        this._mover.reset(this._position);
     }
 
     resetToSpawn(camera: Camera): boolean {
@@ -98,7 +80,7 @@ class FlyController implements CameraController {
         this._position.copy(this._spawnPosition);
         this._angles.copy(this._spawnAngles);
         this._distance = this._spawnDistance;
-        this._setLastClearPosition(this._position);
+        this._mover.reset(this._position);
 
         camera.position.copy(this._position);
         camera.angles.copy(this._angles);
@@ -116,147 +98,10 @@ class FlyController implements CameraController {
     }
 
     private _step(move: number[]) {
-        rotation.setFromEulerAngles(this._angles);
-        rotation.transformVector(Vec3.FORWARD, forward);
-        rotation.transformVector(Vec3.RIGHT, right);
-        rotation.transformVector(Vec3.UP, up);
+        setCameraBasis(this._angles, forward, right, up);
 
-        offset.set(0, 0, 0);
-        offset.add(forward.mulScalar(move[2]));
-        offset.add(right.mulScalar(move[0]));
-        offset.add(up.mulScalar(move[1]));
-
-        if (this.collision) {
-            this._moveWithCollision(offset);
-        } else {
-            this._position.add(offset);
-        }
-    }
-
-    private _moveWithCollision(move: Vec3) {
-        remainingMove.copy(move);
-
-        if (this._isMoveComplete(remainingMove)) {
-            this._resolveCurrentPosition();
-            return;
-        }
-
-        for (let i = 0; i < MAX_SLIDE_ITERATIONS; i++) {
-            if (this._isMoveComplete(remainingMove)) {
-                break;
-            }
-
-            if (!this._moveAndSlide(remainingMove)) {
-                break;
-            }
-        }
-    }
-
-    private _moveAndSlide(move: Vec3): boolean {
-        const moveSq = move.x * move.x + move.y * move.y + move.z * move.z;
-        const distance = Math.sqrt(moveSq);
-        sweepDir.copy(move).mulScalar(1 / distance);
-
-        const hit = this.collision!.queryRay(
-            this._position.x, this._position.y, this._position.z,
-            sweepDir.x, sweepDir.y, sweepDir.z,
-            distance + CAMERA_RADIUS + COLLISION_SKIN
-        );
-
-        if (!hit) {
-            this._position.add(move);
-            this._resolveCurrentPosition();
-            return false;
-        }
-
-        const hx = hit.x - this._position.x;
-        const hy = hit.y - this._position.y;
-        const hz = hit.z - this._position.z;
-        const hitDistance = Math.max(0, hx * sweepDir.x + hy * sweepDir.y + hz * sweepDir.z);
-        const travel = math.clamp(hitDistance - CAMERA_RADIUS - COLLISION_SKIN, 0, distance);
-
-        this._position.add(v.copy(sweepDir).mulScalar(travel));
-        this._resolveCurrentPosition();
-
-        const surfaceNormal = this.collision!.querySurfaceNormal(
-            hit.x, hit.y, hit.z,
-            sweepDir.x, sweepDir.y, sweepDir.z
-        );
-        sweepNormal.set(surfaceNormal.nx, surfaceNormal.ny, surfaceNormal.nz);
-
-        move.add(v.copy(sweepDir).mulScalar(-travel));
-        this._clipMove(move, sweepNormal);
-
-        return true;
-    }
-
-    private _resolveCurrentPosition() {
-        if (!this.collision) {
-            this._setLastClearPosition(this._position);
-            return;
-        }
-
-        this._resolveSphere(this._position, collisionPush);
-        if (!this._isSphereClear(this._position) && this._hasLastClearPosition) {
-            this._position.copy(this._lastClearPosition);
-        }
-
-        if (this._isSphereClear(this._position)) {
-            this._setLastClearPosition(this._position);
-        }
-    }
-
-    private _resolveSphere(position: Vec3, push: Vec3): boolean {
-        let collided = false;
-        push.set(0, 0, 0);
-
-        for (let i = 0; i < MAX_COLLISION_PASSES; i++) {
-            if (!this.collision!.querySphere(position.x, position.y, position.z, CAMERA_RADIUS, pushOut)) {
-                break;
-            }
-
-            position.x += pushOut.x;
-            position.y += pushOut.y;
-            position.z += pushOut.z;
-            push.x += pushOut.x;
-            push.y += pushOut.y;
-            push.z += pushOut.z;
-            collided = true;
-        }
-
-        return collided;
-    }
-
-    private _clipMove(move: Vec3, push: Vec3) {
-        const normalSq = push.x * push.x + push.y * push.y + push.z * push.z;
-        if (normalSq <= MIN_MOVE_SQ) {
-            return;
-        }
-
-        const invPushLen = 1 / Math.sqrt(normalSq);
-        const nx = push.x * invPushLen;
-        const ny = push.y * invPushLen;
-        const nz = push.z * invPushLen;
-        const dot = move.x * nx + move.y * ny + move.z * nz;
-
-        if (dot < 0) {
-            move.x -= dot * nx;
-            move.y -= dot * ny;
-            move.z -= dot * nz;
-        }
-    }
-
-    private _isMoveComplete(move: Vec3): boolean {
-        return move.x * move.x + move.y * move.y + move.z * move.z <= MIN_MOVE_SQ;
-    }
-
-    private _isSphereClear(position: Vec3): boolean {
-        return !this.collision!.querySphere(position.x, position.y, position.z, CAMERA_RADIUS, pushOut);
-    }
-
-    private _setLastClearPosition(position: Vec3) {
-        this._lastClearPosition.copy(position);
-        this._hasLastClearPosition = !this.collision || this._isSphereClear(position);
+        setBasisOffset(offset, move[0], move[1], move[2], forward, right, up);
+        this._mover.move(this._position, offset);
     }
 }
 

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -101,13 +101,16 @@ class FlySource {
      * @param target - The destination.
      */
     flyTo(target: Vec3) {
+        const wasFlying = this._target !== null;
         if (!this._target) {
             this._target = new Vec3();
         }
         this._target.copy(target);
-        this._yawRate = 0;
-        this._pitchRate = 0;
-        this._speed = 0;
+        if (!wasFlying) {
+            this._yawRate = 0;
+            this._pitchRate = 0;
+            this._speed = 0;
+        }
         this._progress.reset();
     }
 
@@ -180,9 +183,13 @@ class FlySource {
         const alignmentScale = smoothstep(0.05, 0.95, alignment);
         const brakeSpeed = Math.sqrt(2 * this.moveDeceleration * activeRemainingDist);
         const arrivalSpeed = activeRemainingDist * ARRIVAL_RATE;
-        const desiredSpeed = Math.min(this.flySpeed, brakeSpeed, arrivalSpeed) * alignmentScale;
-        const speedDelta = (desiredSpeed > this._speed ? this.moveAcceleration : this.moveDeceleration) * dt;
-        this._speed = approach(this._speed, desiredSpeed, speedDelta);
+        const maxSpeed = Math.min(this.flySpeed, brakeSpeed, arrivalSpeed);
+
+        if (maxSpeed > this._speed) {
+            this._speed = approach(this._speed, maxSpeed, this.moveAcceleration * alignmentScale * dt);
+        } else {
+            this._speed = approach(this._speed, maxSpeed, this.moveDeceleration * dt);
+        }
 
         const arrivalMove = activeRemainingDist * (1 - Math.exp(-ARRIVAL_RATE * dt));
         const moveDist = Math.min(this._speed * dt, arrivalMove);

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -14,6 +14,18 @@ const MIN_STOP_DIST = 0.75;
 /** Maximum standoff from the target */
 const MAX_STOP_DIST = 4.0;
 
+/** Distance from the standoff point below which arrival can complete */
+const ARRIVAL_EPSILON = 0.03;
+
+/** Forward speed below which arrival can complete */
+const ARRIVAL_SPEED = 0.05;
+
+/** Minimum distance over which to ease into the standoff point */
+const MIN_SLOW_DIST = 0.9;
+
+/** FOV standoff multiplier used as the slow-down zone */
+const SLOW_DIST_RATIO = 0.6;
+
 /** Minimum progress speed (m/s) to not count as blocked */
 const BLOCKED_SPEED = 0.25;
 
@@ -161,7 +173,7 @@ class FlySource {
         const stopDistance = getStopDistance(cameraFov);
         const remainingDist = dist - stopDistance;
 
-        if (remainingDist <= 0) {
+        if (remainingDist <= ARRIVAL_EPSILON && this._speed <= ARRIVAL_SPEED) {
             this.cancelFly();
             return;
         }
@@ -201,11 +213,13 @@ class FlySource {
         const alignment = math.clamp(forward.x * dirX + forward.y * dirY + forward.z * dirZ, 0, 1);
         const alignmentScale = smoothstep(0.05, 0.95, alignment);
         const brakeSpeed = Math.sqrt(Math.max(0, 2 * this.moveDeceleration * remainingDist));
-        const desiredSpeed = Math.min(this.flySpeed, brakeSpeed) * alignmentScale;
+        const slowDistance = Math.max(MIN_SLOW_DIST, stopDistance * SLOW_DIST_RATIO);
+        const arrivalScale = smoothstep(ARRIVAL_EPSILON, slowDistance, remainingDist);
+        const desiredSpeed = Math.min(this.flySpeed * arrivalScale, brakeSpeed) * alignmentScale;
         const speedDelta = (desiredSpeed > this._speed ? this.moveAcceleration : this.moveDeceleration) * dt;
         this._speed = approach(this._speed, desiredSpeed, speedDelta);
 
-        const moveDist = Math.min(this._speed * dt, remainingDist);
+        const moveDist = Math.min(this._speed * dt, Math.max(0, remainingDist - ARRIVAL_EPSILON));
         if (moveDist > 0) {
             frame.deltas.move.append([0, 0, moveDist]);
         }

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -1,0 +1,161 @@
+import { math, Quat, Vec3 } from 'playcanvas';
+
+import type { CameraFrame } from './camera';
+
+const RAD_TO_DEG = 180 / Math.PI;
+
+/** 3D distance below which the flyer considers itself arrived */
+const ARRIVAL_DIST = 0.5;
+
+/** Minimum progress speed (m/s) to not count as blocked */
+const BLOCKED_SPEED = 0.25;
+
+/** Seconds of continuous low-progress before stopping the flight */
+const BLOCKED_DURATION = 0.5;
+
+const toTarget = new Vec3();
+const forward = new Vec3();
+const rotation = new Quat();
+
+const shortestAngle = (angle: number) => ((angle % 360) + 540) % 360 - 180;
+
+/**
+ * Generates synthetic move/rotate input to auto-fly toward a target position.
+ */
+class FlySource {
+    /**
+     * Forward input scale (matches InputController.moveSpeed).
+     */
+    flySpeed = 4;
+
+    /**
+     * Maximum pitch/yaw turn rate in degrees per second.
+     */
+    maxTurnRate = 240;
+
+    /**
+     * Proportional gain mapping angular error (degrees) to desired turn rate.
+     */
+    turnGain = 5;
+
+    /**
+     * Callback fired when an auto-flight completes or is cancelled.
+     */
+    onComplete: (() => void) | null = null;
+
+    private _target: Vec3 | null = null;
+
+    private _yawRate = 0;
+
+    private _pitchRate = 0;
+
+    private _blockedTime = 0;
+
+    private _prevDist = Infinity;
+
+    get isFlying(): boolean {
+        return this._target !== null;
+    }
+
+    /**
+     * Begin auto-flying toward a world-space target position.
+     *
+     * @param target - The destination.
+     */
+    flyTo(target: Vec3) {
+        if (!this._target) {
+            this._target = new Vec3();
+        }
+        this._target.copy(target);
+        this._blockedTime = 0;
+        this._prevDist = Infinity;
+    }
+
+    /**
+     * Cancel any active auto-flight.
+     */
+    cancelFly() {
+        if (this._target) {
+            this._target = null;
+            this._yawRate = 0;
+            this._pitchRate = 0;
+            this._blockedTime = 0;
+            this._prevDist = Infinity;
+            this.onComplete?.();
+        }
+    }
+
+    /**
+     * Compute fly deltas and append them to the frame. Must be called before
+     * the camera controller reads the frame.
+     *
+     * @param dt - Frame delta time in seconds.
+     * @param cameraPosition - Camera world position.
+     * @param cameraAngles - Camera Euler angles in degrees.
+     * @param frame - The shared CameraFrame to append deltas to.
+     */
+    update(dt: number, cameraPosition: Vec3, cameraAngles: Vec3, frame: CameraFrame) {
+        if (!this._target) return;
+
+        const target = this._target;
+        toTarget.sub2(target, cameraPosition);
+        const dist = toTarget.length();
+
+        if (dist < ARRIVAL_DIST) {
+            this.cancelFly();
+            return;
+        }
+
+        if (dt <= 0) {
+            return;
+        }
+
+        const invDist = 1 / dist;
+        const dirX = toTarget.x * invDist;
+        const dirY = toTarget.y * invDist;
+        const dirZ = toTarget.z * invDist;
+
+        const targetPitch = Math.asin(math.clamp(dirY, -1, 1)) * RAD_TO_DEG;
+        const targetYaw = Math.atan2(-dirX, -dirZ) * RAD_TO_DEG;
+
+        const yawDiff = shortestAngle(targetYaw - cameraAngles.y);
+        const pitchDiff = targetPitch - cameraAngles.x;
+
+        const desiredYawRate = math.clamp(yawDiff * this.turnGain, -this.maxTurnRate, this.maxTurnRate);
+        const desiredPitchRate = math.clamp(pitchDiff * this.turnGain, -this.maxTurnRate, this.maxTurnRate);
+        const smoothing = 1 - Math.exp(-4 * this.turnGain * dt);
+
+        this._yawRate += (desiredYawRate - this._yawRate) * smoothing;
+        this._pitchRate += (desiredPitchRate - this._pitchRate) * smoothing;
+
+        // FlyController applies: _angles += [-rotateY, -rotateX, 0]
+        frame.deltas.rotate.append([-(this._yawRate * dt), -(this._pitchRate * dt), 0]);
+
+        rotation.setFromEulerAngles(cameraAngles);
+        rotation.transformVector(Vec3.FORWARD, forward);
+
+        const alignment = math.clamp(forward.x * dirX + forward.y * dirY + forward.z * dirZ, 0, 1);
+        const moveDist = Math.min(this.flySpeed * dt * alignment, Math.max(0, dist - ARRIVAL_DIST));
+        if (moveDist > 0) {
+            frame.deltas.move.append([0, 0, moveDist]);
+        }
+
+        // Only treat low progress as blocked once the camera is substantially
+        // facing the target; otherwise a large turn-in-place would cancel early.
+        if (alignment > 0.5 && this._prevDist !== Infinity) {
+            const speed = (this._prevDist - dist) / dt;
+            if (speed < BLOCKED_SPEED) {
+                this._blockedTime += dt;
+                if (this._blockedTime >= BLOCKED_DURATION) {
+                    this.cancelFly();
+                    return;
+                }
+            } else {
+                this._blockedTime = 0;
+            }
+        }
+        this._prevDist = dist;
+    }
+}
+
+export { FlySource };

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -1,8 +1,17 @@
-import { math, Quat, Vec3 } from 'playcanvas';
+import { math, Vec3 } from 'playcanvas';
 
 import type { CameraFrame } from './camera';
+import { setCameraForward } from './camera-utils';
+import {
+    ProgressTracker,
+    approach,
+    clampTurnStep,
+    getPitchToDirection,
+    getYawDiffToTarget,
+    smoothTurnRate,
+    smoothstep
+} from './target-navigation';
 
-const RAD_TO_DEG = 180 / Math.PI;
 const DEG_TO_RAD = Math.PI / 180;
 
 /** Target-space radius to keep visible at the stopping distance */
@@ -31,37 +40,11 @@ const BLOCKED_DURATION = 0.5;
 
 const toTarget = new Vec3();
 const forward = new Vec3();
-const rotation = new Quat();
-
-const shortestAngle = (angle: number) => ((angle % 360) + 540) % 360 - 180;
+const postTurnAngles = new Vec3();
 
 const getStopDistance = (fov: number) => {
     const halfFov = math.clamp(fov, 15, 120) * DEG_TO_RAD * 0.5;
     return math.clamp(STOP_VIEW_RADIUS / Math.tan(halfFov), MIN_STOP_DIST, MAX_STOP_DIST);
-};
-
-const approach = (value: number, target: number, maxDelta: number) => {
-    if (value < target) {
-        return Math.min(target, value + maxDelta);
-    }
-
-    return Math.max(target, value - maxDelta);
-};
-
-const smoothstep = (edge0: number, edge1: number, value: number) => {
-    const t = math.clamp((value - edge0) / (edge1 - edge0), 0, 1);
-    return t * t * (3 - 2 * t);
-};
-
-const clampStep = (rate: number, remaining: number, dt: number) => {
-    const step = rate * dt;
-    if (Math.abs(remaining) < 1e-4) {
-        return 0;
-    }
-
-    return Math.sign(step) === Math.sign(remaining) && Math.abs(step) > Math.abs(remaining) ?
-        remaining :
-        step;
 };
 
 /**
@@ -82,11 +65,6 @@ class FlySource {
      * Proportional gain mapping angular error (degrees) to desired turn rate.
      */
     turnGain = 4;
-
-    /**
-     * Maximum pitch/yaw turn acceleration in degrees per second squared.
-     */
-    turnAcceleration = 720;
 
     /**
      * Maximum forward acceleration in meters per second squared.
@@ -111,9 +89,7 @@ class FlySource {
 
     private _speed = 0;
 
-    private _blockedTime = 0;
-
-    private _prevDist = Infinity;
+    private _progress = new ProgressTracker();
 
     get isFlying(): boolean {
         return this._target !== null;
@@ -132,8 +108,7 @@ class FlySource {
         this._yawRate = 0;
         this._pitchRate = 0;
         this._speed = 0;
-        this._blockedTime = 0;
-        this._prevDist = Infinity;
+        this._progress.reset();
     }
 
     /**
@@ -145,8 +120,7 @@ class FlySource {
             this._yawRate = 0;
             this._pitchRate = 0;
             this._speed = 0;
-            this._blockedTime = 0;
-            this._prevDist = Infinity;
+            this._progress.reset();
             this.onComplete?.();
         }
     }
@@ -185,28 +159,22 @@ class FlySource {
         const dirY = toTarget.y * invDist;
         const dirZ = toTarget.z * invDist;
 
-        const targetPitch = Math.asin(math.clamp(dirY, -1, 1)) * RAD_TO_DEG;
-        const targetYaw = Math.atan2(-dirX, -dirZ) * RAD_TO_DEG;
+        const yawDiff = getYawDiffToTarget(toTarget.x, toTarget.z, cameraAngles.y);
+        const pitchDiff = getPitchToDirection(dirY) - cameraAngles.x;
 
-        const yawDiff = shortestAngle(targetYaw - cameraAngles.y);
-        const pitchDiff = targetPitch - cameraAngles.x;
+        this._yawRate = smoothTurnRate(this._yawRate, yawDiff, this.maxTurnRate, this.turnGain, dt);
+        this._pitchRate = smoothTurnRate(this._pitchRate, pitchDiff, this.maxTurnRate, this.turnGain, dt);
 
-        const desiredYawRate = math.clamp(yawDiff * this.turnGain, -this.maxTurnRate, this.maxTurnRate);
-        const desiredPitchRate = math.clamp(pitchDiff * this.turnGain, -this.maxTurnRate, this.maxTurnRate);
-
-        this._yawRate = approach(this._yawRate, desiredYawRate, this.turnAcceleration * dt);
-        this._pitchRate = approach(this._pitchRate, desiredPitchRate, this.turnAcceleration * dt);
-
-        const yawStep = clampStep(this._yawRate, yawDiff, dt);
-        const pitchStep = clampStep(this._pitchRate, pitchDiff, dt);
+        const yawStep = clampTurnStep(this._yawRate, yawDiff, dt);
+        const pitchStep = clampTurnStep(this._pitchRate, pitchDiff, dt);
         this._yawRate = yawStep / dt;
         this._pitchRate = pitchStep / dt;
 
         // FlyController applies: _angles += [-rotateY, -rotateX, 0]
         frame.deltas.rotate.append([-yawStep, -pitchStep, 0]);
 
-        rotation.setFromEulerAngles(cameraAngles.x + pitchStep, cameraAngles.y + yawStep, 0);
-        rotation.transformVector(Vec3.FORWARD, forward);
+        postTurnAngles.set(cameraAngles.x + pitchStep, cameraAngles.y + yawStep, 0);
+        setCameraForward(postTurnAngles, forward);
 
         const alignment = math.clamp(forward.x * dirX + forward.y * dirY + forward.z * dirZ, 0, 1);
         const alignmentScale = smoothstep(0.05, 0.95, alignment);
@@ -224,19 +192,9 @@ class FlySource {
 
         // Only treat low progress as blocked once the camera is substantially
         // facing the target; otherwise a large turn-in-place would cancel early.
-        if (alignment > 0.5 && this._speed > BLOCKED_SPEED && this._prevDist !== Infinity) {
-            const speed = (this._prevDist - dist) / dt;
-            if (speed < BLOCKED_SPEED) {
-                this._blockedTime += dt;
-                if (this._blockedTime >= BLOCKED_DURATION) {
-                    this.cancelFly();
-                    return;
-                }
-            } else {
-                this._blockedTime = 0;
-            }
+        if (this._progress.update(dist, dt, BLOCKED_SPEED, BLOCKED_DURATION, alignment > 0.5 && this._speed > BLOCKED_SPEED)) {
+            this.cancelFly();
         }
-        this._prevDist = dist;
     }
 }
 

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -3,9 +3,16 @@ import { math, Quat, Vec3 } from 'playcanvas';
 import type { CameraFrame } from './camera';
 
 const RAD_TO_DEG = 180 / Math.PI;
+const DEG_TO_RAD = Math.PI / 180;
 
-/** 3D distance below which the flyer considers itself arrived */
-const ARRIVAL_DIST = 0.5;
+/** Target-space radius to keep visible at the stopping distance */
+const STOP_VIEW_RADIUS = 0.75;
+
+/** Minimum standoff from the target */
+const MIN_STOP_DIST = 0.75;
+
+/** Maximum standoff from the target */
+const MAX_STOP_DIST = 4.0;
 
 /** Minimum progress speed (m/s) to not count as blocked */
 const BLOCKED_SPEED = 0.25;
@@ -19,6 +26,35 @@ const rotation = new Quat();
 
 const shortestAngle = (angle: number) => ((angle % 360) + 540) % 360 - 180;
 
+const getStopDistance = (fov: number) => {
+    const halfFov = math.clamp(fov, 15, 120) * DEG_TO_RAD * 0.5;
+    return math.clamp(STOP_VIEW_RADIUS / Math.tan(halfFov), MIN_STOP_DIST, MAX_STOP_DIST);
+};
+
+const approach = (value: number, target: number, maxDelta: number) => {
+    if (value < target) {
+        return Math.min(target, value + maxDelta);
+    }
+
+    return Math.max(target, value - maxDelta);
+};
+
+const smoothstep = (edge0: number, edge1: number, value: number) => {
+    const t = math.clamp((value - edge0) / (edge1 - edge0), 0, 1);
+    return t * t * (3 - 2 * t);
+};
+
+const clampStep = (rate: number, remaining: number, dt: number) => {
+    const step = rate * dt;
+    if (Math.abs(remaining) < 1e-4) {
+        return 0;
+    }
+
+    return Math.sign(step) === Math.sign(remaining) && Math.abs(step) > Math.abs(remaining) ?
+        remaining :
+        step;
+};
+
 /**
  * Generates synthetic move/rotate input to auto-fly toward a target position.
  */
@@ -31,12 +67,27 @@ class FlySource {
     /**
      * Maximum pitch/yaw turn rate in degrees per second.
      */
-    maxTurnRate = 240;
+    maxTurnRate = 180;
 
     /**
      * Proportional gain mapping angular error (degrees) to desired turn rate.
      */
-    turnGain = 5;
+    turnGain = 4;
+
+    /**
+     * Maximum pitch/yaw turn acceleration in degrees per second squared.
+     */
+    turnAcceleration = 720;
+
+    /**
+     * Maximum forward acceleration in meters per second squared.
+     */
+    moveAcceleration = 6;
+
+    /**
+     * Maximum forward braking in meters per second squared.
+     */
+    moveDeceleration = 8;
 
     /**
      * Callback fired when an auto-flight completes or is cancelled.
@@ -48,6 +99,8 @@ class FlySource {
     private _yawRate = 0;
 
     private _pitchRate = 0;
+
+    private _speed = 0;
 
     private _blockedTime = 0;
 
@@ -67,6 +120,9 @@ class FlySource {
             this._target = new Vec3();
         }
         this._target.copy(target);
+        this._yawRate = 0;
+        this._pitchRate = 0;
+        this._speed = 0;
         this._blockedTime = 0;
         this._prevDist = Infinity;
     }
@@ -79,6 +135,7 @@ class FlySource {
             this._target = null;
             this._yawRate = 0;
             this._pitchRate = 0;
+            this._speed = 0;
             this._blockedTime = 0;
             this._prevDist = Infinity;
             this.onComplete?.();
@@ -92,16 +149,19 @@ class FlySource {
      * @param dt - Frame delta time in seconds.
      * @param cameraPosition - Camera world position.
      * @param cameraAngles - Camera Euler angles in degrees.
+     * @param cameraFov - Camera vertical field-of-view in degrees.
      * @param frame - The shared CameraFrame to append deltas to.
      */
-    update(dt: number, cameraPosition: Vec3, cameraAngles: Vec3, frame: CameraFrame) {
+    update(dt: number, cameraPosition: Vec3, cameraAngles: Vec3, cameraFov: number, frame: CameraFrame) {
         if (!this._target) return;
 
         const target = this._target;
         toTarget.sub2(target, cameraPosition);
         const dist = toTarget.length();
+        const stopDistance = getStopDistance(cameraFov);
+        const remainingDist = dist - stopDistance;
 
-        if (dist < ARRIVAL_DIST) {
+        if (remainingDist <= 0) {
             this.cancelFly();
             return;
         }
@@ -123,26 +183,36 @@ class FlySource {
 
         const desiredYawRate = math.clamp(yawDiff * this.turnGain, -this.maxTurnRate, this.maxTurnRate);
         const desiredPitchRate = math.clamp(pitchDiff * this.turnGain, -this.maxTurnRate, this.maxTurnRate);
-        const smoothing = 1 - Math.exp(-4 * this.turnGain * dt);
 
-        this._yawRate += (desiredYawRate - this._yawRate) * smoothing;
-        this._pitchRate += (desiredPitchRate - this._pitchRate) * smoothing;
+        this._yawRate = approach(this._yawRate, desiredYawRate, this.turnAcceleration * dt);
+        this._pitchRate = approach(this._pitchRate, desiredPitchRate, this.turnAcceleration * dt);
+
+        const yawStep = clampStep(this._yawRate, yawDiff, dt);
+        const pitchStep = clampStep(this._pitchRate, pitchDiff, dt);
+        this._yawRate = yawStep / dt;
+        this._pitchRate = pitchStep / dt;
 
         // FlyController applies: _angles += [-rotateY, -rotateX, 0]
-        frame.deltas.rotate.append([-(this._yawRate * dt), -(this._pitchRate * dt), 0]);
+        frame.deltas.rotate.append([-yawStep, -pitchStep, 0]);
 
-        rotation.setFromEulerAngles(cameraAngles);
+        rotation.setFromEulerAngles(cameraAngles.x + pitchStep, cameraAngles.y + yawStep, 0);
         rotation.transformVector(Vec3.FORWARD, forward);
 
         const alignment = math.clamp(forward.x * dirX + forward.y * dirY + forward.z * dirZ, 0, 1);
-        const moveDist = Math.min(this.flySpeed * dt * alignment, Math.max(0, dist - ARRIVAL_DIST));
+        const alignmentScale = smoothstep(0.05, 0.95, alignment);
+        const brakeSpeed = Math.sqrt(Math.max(0, 2 * this.moveDeceleration * remainingDist));
+        const desiredSpeed = Math.min(this.flySpeed, brakeSpeed) * alignmentScale;
+        const speedDelta = (desiredSpeed > this._speed ? this.moveAcceleration : this.moveDeceleration) * dt;
+        this._speed = approach(this._speed, desiredSpeed, speedDelta);
+
+        const moveDist = Math.min(this._speed * dt, remainingDist);
         if (moveDist > 0) {
             frame.deltas.move.append([0, 0, moveDist]);
         }
 
         // Only treat low progress as blocked once the camera is substantially
         // facing the target; otherwise a large turn-in-place would cancel early.
-        if (alignment > 0.5 && this._prevDist !== Infinity) {
+        if (alignment > 0.5 && this._speed > BLOCKED_SPEED && this._prevDist !== Infinity) {
             const speed = (this._prevDist - dist) / dt;
             if (speed < BLOCKED_SPEED) {
                 this._blockedTime += dt;

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -20,11 +20,8 @@ const ARRIVAL_EPSILON = 0.03;
 /** Forward speed below which arrival can complete */
 const ARRIVAL_SPEED = 0.05;
 
-/** Minimum distance over which to ease into the standoff point */
-const MIN_SLOW_DIST = 0.9;
-
-/** FOV standoff multiplier used as the slow-down zone */
-const SLOW_DIST_RATIO = 0.6;
+/** Converts remaining standoff distance to final approach speed */
+const ARRIVAL_RATE = 1.75;
 
 /** Minimum progress speed (m/s) to not count as blocked */
 const BLOCKED_SPEED = 0.25;
@@ -172,8 +169,9 @@ class FlySource {
         const dist = toTarget.length();
         const stopDistance = getStopDistance(cameraFov);
         const remainingDist = dist - stopDistance;
+        const activeRemainingDist = Math.max(0, remainingDist);
 
-        if (remainingDist <= ARRIVAL_EPSILON && this._speed <= ARRIVAL_SPEED) {
+        if (activeRemainingDist <= ARRIVAL_EPSILON && this._speed <= ARRIVAL_SPEED) {
             this.cancelFly();
             return;
         }
@@ -212,14 +210,14 @@ class FlySource {
 
         const alignment = math.clamp(forward.x * dirX + forward.y * dirY + forward.z * dirZ, 0, 1);
         const alignmentScale = smoothstep(0.05, 0.95, alignment);
-        const brakeSpeed = Math.sqrt(Math.max(0, 2 * this.moveDeceleration * remainingDist));
-        const slowDistance = Math.max(MIN_SLOW_DIST, stopDistance * SLOW_DIST_RATIO);
-        const arrivalScale = smoothstep(ARRIVAL_EPSILON, slowDistance, remainingDist);
-        const desiredSpeed = Math.min(this.flySpeed * arrivalScale, brakeSpeed) * alignmentScale;
+        const brakeSpeed = Math.sqrt(2 * this.moveDeceleration * activeRemainingDist);
+        const arrivalSpeed = activeRemainingDist * ARRIVAL_RATE;
+        const desiredSpeed = Math.min(this.flySpeed, brakeSpeed, arrivalSpeed) * alignmentScale;
         const speedDelta = (desiredSpeed > this._speed ? this.moveAcceleration : this.moveDeceleration) * dt;
         this._speed = approach(this._speed, desiredSpeed, speedDelta);
 
-        const moveDist = Math.min(this._speed * dt, Math.max(0, remainingDist - ARRIVAL_EPSILON));
+        const arrivalMove = activeRemainingDist * (1 - Math.exp(-ARRIVAL_RATE * dt));
+        const moveDist = Math.min(this._speed * dt, arrivalMove);
         if (moveDist > 0) {
             frame.deltas.move.append([0, 0, moveDist]);
         }

--- a/src/cameras/orbit-controller.ts
+++ b/src/cameras/orbit-controller.ts
@@ -1,53 +1,96 @@
-import {
-    OrbitController as OrbitControllerPC,
-    Pose,
-    Vec2
-} from 'playcanvas';
+import { math, Vec3 } from 'playcanvas';
 
 import type { Camera, CameraFrame, CameraController } from './camera';
+import { applyFrameRotation, dampAlpha, lerpAngles, setBasisOffset, setCameraBasis } from './camera-utils';
 
-const p = new Pose();
+const MIN_DISTANCE = 0.01;
+const MAX_DISTANCE = Infinity;
+
+const focus = new Vec3();
+const forward = new Vec3();
+const right = new Vec3();
+const up = new Vec3();
+const pan = new Vec3();
 
 class OrbitController implements CameraController {
-    controller: OrbitControllerPC;
-
     fov = 90;
 
-    constructor() {
-        this.controller = new OrbitControllerPC();
-        this.controller.zoomRange = new Vec2(0.01, Infinity);
-        this.controller.pitchRange = new Vec2(-90, 90);
-        this.controller.rotateDamping = 0.97;
-        this.controller.moveDamping = 0.97;
-        this.controller.zoomDamping = 0.97;
-    }
+    rotateDamping = 0.97;
+
+    moveDamping = 0.97;
+
+    zoomDamping = 0.97;
+
+    private _focus = new Vec3();
+
+    private _targetFocus = new Vec3();
+
+    private _angles = new Vec3();
+
+    private _targetAngles = new Vec3();
+
+    private _distance = 1;
+
+    private _targetDistance = 1;
 
     onEnter(camera: Camera): void {
-        p.position.copy(camera.position);
-        p.angles.copy(camera.angles);
-        p.distance = camera.distance;
-        this.controller.attach(p, false);
+        this._syncPose(camera, false);
     }
 
     update(deltaTime: number, inputFrame: CameraFrame, camera: Camera) {
-        const pose = this.controller.update(inputFrame, deltaTime);
+        const { move, rotate } = inputFrame.read();
 
-        camera.position.copy(pose.position);
-        camera.angles.copy(pose.angles);
-        camera.distance = pose.distance;
+        setCameraBasis(this._angles, forward, right, up);
+
+        setBasisOffset(pan, move[0], move[1], 0, forward, right, up);
+        this._targetFocus.add(pan);
+
+        this._targetDistance = math.clamp(
+            this._targetDistance * (1 + move[2]),
+            MIN_DISTANCE,
+            MAX_DISTANCE
+        );
+
+        applyFrameRotation(this._targetAngles, rotate);
+
+        this._focus.lerp(this._focus, this._targetFocus, dampAlpha(this.moveDamping, deltaTime));
+        lerpAngles(this._angles, this._angles, this._targetAngles, dampAlpha(this.rotateDamping, deltaTime));
+        this._distance = math.lerp(
+            this._distance,
+            this._targetDistance,
+            dampAlpha(this.zoomDamping, deltaTime)
+        );
+
+        setCameraBasis(this._angles, forward, right, up);
+        camera.position.copy(this._focus).sub(forward.mulScalar(this._distance));
+        camera.angles.copy(this._angles);
+        camera.distance = this._distance;
         camera.fov = this.fov;
     }
 
-    onExit(camera: Camera): void {
+    onExit(_camera: Camera): void {
 
     }
 
     goto(camera: Camera) {
-        p.position.copy(camera.position);
-        p.angles.copy(camera.angles);
-        p.distance = camera.distance;
-        this.fov = camera.fov;
-        this.controller.attach(p, false);
+        this._syncPose(camera, true);
+    }
+
+    private _syncPose(camera: Camera, copyFov: boolean) {
+        camera.calcFocusPoint(focus);
+
+        this._focus.copy(focus);
+        this._targetFocus.copy(focus);
+
+        this._angles.copy(camera.angles);
+        this._targetAngles.copy(camera.angles);
+
+        this._distance = math.clamp(camera.distance, MIN_DISTANCE, MAX_DISTANCE);
+        this._targetDistance = this._distance;
+
+        if (copyFov) {
+            this.fov = camera.fov;
+        }
     }
 }
 

--- a/src/cameras/sphere-mover.ts
+++ b/src/cameras/sphere-mover.ts
@@ -1,0 +1,175 @@
+import { math, Vec3 } from 'playcanvas';
+
+import type { Collision, PushOut } from '../collision';
+
+/** Extra resolve passes above the collider's internal iteration for tight corners */
+const MAX_COLLISION_PASSES = 4;
+
+/** Small clearance that keeps the sphere from resting exactly on a voxel face */
+const COLLISION_SKIN = 1e-3;
+
+/** Maximum surface planes to slide along in a single frame */
+const MAX_SLIDE_ITERATIONS = 3;
+
+const MIN_MOVE_SQ = 1e-10;
+
+const v = new Vec3();
+const remainingMove = new Vec3();
+const collisionPush = new Vec3();
+const sweepDir = new Vec3();
+const sweepNormal = new Vec3();
+
+/** Pre-allocated push-out vector for sphere collision */
+const pushOut: PushOut = { x: 0, y: 0, z: 0 };
+
+class SphereMover {
+    collision: Collision | null = null;
+
+    readonly radius: number;
+
+    private _lastClearPosition = new Vec3();
+
+    private _hasLastClearPosition = false;
+
+    constructor(radius: number) {
+        this.radius = radius;
+    }
+
+    reset(position: Vec3) {
+        this._setLastClearPosition(position);
+    }
+
+    move(position: Vec3, move: Vec3) {
+        if (!this.collision) {
+            position.add(move);
+            this._setLastClearPosition(position);
+            return;
+        }
+
+        remainingMove.copy(move);
+
+        if (this._isMoveComplete(remainingMove)) {
+            this.resolve(position);
+            return;
+        }
+
+        for (let i = 0; i < MAX_SLIDE_ITERATIONS; i++) {
+            if (this._isMoveComplete(remainingMove)) {
+                break;
+            }
+
+            if (!this._moveAndSlide(position, remainingMove)) {
+                break;
+            }
+        }
+    }
+
+    resolve(position: Vec3) {
+        if (!this.collision) {
+            this._setLastClearPosition(position);
+            return;
+        }
+
+        this._resolveSphere(position, collisionPush);
+        if (!this._isSphereClear(position) && this._hasLastClearPosition) {
+            position.copy(this._lastClearPosition);
+        }
+
+        if (this._isSphereClear(position)) {
+            this._setLastClearPosition(position);
+        }
+    }
+
+    private _moveAndSlide(position: Vec3, move: Vec3): boolean {
+        const moveSq = move.x * move.x + move.y * move.y + move.z * move.z;
+        const distance = Math.sqrt(moveSq);
+        sweepDir.copy(move).mulScalar(1 / distance);
+
+        const hit = this.collision!.queryRay(
+            position.x, position.y, position.z,
+            sweepDir.x, sweepDir.y, sweepDir.z,
+            distance + this.radius + COLLISION_SKIN
+        );
+
+        if (!hit) {
+            position.add(move);
+            this.resolve(position);
+            return false;
+        }
+
+        const hx = hit.x - position.x;
+        const hy = hit.y - position.y;
+        const hz = hit.z - position.z;
+        const hitDistance = Math.max(0, hx * sweepDir.x + hy * sweepDir.y + hz * sweepDir.z);
+        const travel = math.clamp(hitDistance - this.radius - COLLISION_SKIN, 0, distance);
+
+        position.add(v.copy(sweepDir).mulScalar(travel));
+        this.resolve(position);
+
+        const surfaceNormal = this.collision!.querySurfaceNormal(
+            hit.x, hit.y, hit.z,
+            sweepDir.x, sweepDir.y, sweepDir.z
+        );
+        sweepNormal.set(surfaceNormal.nx, surfaceNormal.ny, surfaceNormal.nz);
+
+        move.add(v.copy(sweepDir).mulScalar(-travel));
+        this._clipMove(move, sweepNormal);
+
+        return true;
+    }
+
+    private _resolveSphere(position: Vec3, push: Vec3): boolean {
+        let collided = false;
+        push.set(0, 0, 0);
+
+        for (let i = 0; i < MAX_COLLISION_PASSES; i++) {
+            if (!this.collision!.querySphere(position.x, position.y, position.z, this.radius, pushOut)) {
+                break;
+            }
+
+            position.x += pushOut.x;
+            position.y += pushOut.y;
+            position.z += pushOut.z;
+            push.x += pushOut.x;
+            push.y += pushOut.y;
+            push.z += pushOut.z;
+            collided = true;
+        }
+
+        return collided;
+    }
+
+    private _clipMove(move: Vec3, push: Vec3) {
+        const normalSq = push.x * push.x + push.y * push.y + push.z * push.z;
+        if (normalSq <= MIN_MOVE_SQ) {
+            return;
+        }
+
+        const invPushLen = 1 / Math.sqrt(normalSq);
+        const nx = push.x * invPushLen;
+        const ny = push.y * invPushLen;
+        const nz = push.z * invPushLen;
+        const dot = move.x * nx + move.y * ny + move.z * nz;
+
+        if (dot < 0) {
+            move.x -= dot * nx;
+            move.y -= dot * ny;
+            move.z -= dot * nz;
+        }
+    }
+
+    private _isMoveComplete(move: Vec3): boolean {
+        return move.x * move.x + move.y * move.y + move.z * move.z <= MIN_MOVE_SQ;
+    }
+
+    private _isSphereClear(position: Vec3): boolean {
+        return !this.collision!.querySphere(position.x, position.y, position.z, this.radius, pushOut);
+    }
+
+    private _setLastClearPosition(position: Vec3) {
+        this._lastClearPosition.copy(position);
+        this._hasLastClearPosition = !this.collision || this._isSphereClear(position);
+    }
+}
+
+export { SphereMover };

--- a/src/cameras/sphere-mover.ts
+++ b/src/cameras/sphere-mover.ts
@@ -5,7 +5,7 @@ import type { Collision, PushOut } from '../collision';
 /** Extra resolve passes above the collider's internal iteration for tight corners */
 const MAX_COLLISION_PASSES = 4;
 
-/** Small clearance that keeps the sphere from resting exactly on a voxel face */
+/** Small clearance that keeps the sphere from resting exactly on a collision surface */
 const COLLISION_SKIN = 1e-3;
 
 /** Maximum surface planes to slide along in a single frame */

--- a/src/cameras/sphere-mover.ts
+++ b/src/cameras/sphere-mover.ts
@@ -12,15 +12,53 @@ const COLLISION_SKIN = 1e-3;
 const MAX_SLIDE_ITERATIONS = 3;
 
 const MIN_MOVE_SQ = 1e-10;
+const INV_SQRT2 = 1 / Math.sqrt(2);
+
+const SWEEP_RAY_OFFSETS = [
+    [0, 0, true],
+    [1, 0, false],
+    [-1, 0, false],
+    [0, 1, false],
+    [0, -1, false],
+    [INV_SQRT2, INV_SQRT2, false],
+    [-INV_SQRT2, INV_SQRT2, false],
+    [-INV_SQRT2, -INV_SQRT2, false],
+    [INV_SQRT2, -INV_SQRT2, false]
+] as const;
 
 const v = new Vec3();
 const remainingMove = new Vec3();
 const collisionPush = new Vec3();
 const sweepDir = new Vec3();
 const sweepNormal = new Vec3();
+const sweepTangent = new Vec3();
+const sweepBitangent = new Vec3();
+const sweepOrigin = new Vec3();
+const worldUp = new Vec3(0, 1, 0);
+const worldRight = new Vec3(1, 0, 0);
 
 /** Pre-allocated push-out vector for sphere collision */
 const pushOut: PushOut = { x: 0, y: 0, z: 0 };
+
+type SweepHit = {
+    x: number;
+    y: number;
+    z: number;
+    nx: number;
+    ny: number;
+    nz: number;
+    travel: number;
+};
+
+const sweepHit: SweepHit = {
+    x: 0,
+    y: 0,
+    z: 0,
+    nx: 0,
+    ny: 1,
+    nz: 0,
+    travel: 0
+};
 
 class SphereMover {
     collision: Collision | null = null;
@@ -85,37 +123,81 @@ class SphereMover {
         const distance = Math.sqrt(moveSq);
         sweepDir.copy(move).mulScalar(1 / distance);
 
-        const hit = this.collision!.queryRay(
-            position.x, position.y, position.z,
-            sweepDir.x, sweepDir.y, sweepDir.z,
-            distance + this.radius + COLLISION_SKIN
-        );
-
-        if (!hit) {
+        if (!this._querySweep(position, sweepDir, distance, sweepHit)) {
             position.add(move);
             this.resolve(position);
             return false;
         }
 
-        const hx = hit.x - position.x;
-        const hy = hit.y - position.y;
-        const hz = hit.z - position.z;
-        const hitDistance = Math.max(0, hx * sweepDir.x + hy * sweepDir.y + hz * sweepDir.z);
-        const travel = math.clamp(hitDistance - this.radius - COLLISION_SKIN, 0, distance);
-
-        position.add(v.copy(sweepDir).mulScalar(travel));
+        position.add(v.copy(sweepDir).mulScalar(sweepHit.travel));
         this.resolve(position);
 
-        const surfaceNormal = this.collision!.querySurfaceNormal(
-            hit.x, hit.y, hit.z,
-            sweepDir.x, sweepDir.y, sweepDir.z
-        );
-        sweepNormal.set(surfaceNormal.nx, surfaceNormal.ny, surfaceNormal.nz);
+        sweepNormal.set(sweepHit.nx, sweepHit.ny, sweepHit.nz);
 
-        move.add(v.copy(sweepDir).mulScalar(-travel));
+        move.add(v.copy(sweepDir).mulScalar(-sweepHit.travel));
         this._clipMove(move, sweepNormal);
 
         return true;
+    }
+
+    private _querySweep(position: Vec3, dir: Vec3, distance: number, out: SweepHit): boolean {
+        if (Math.abs(dir.y) < 0.99) {
+            sweepTangent.cross(dir, worldUp).normalize();
+        } else {
+            sweepTangent.cross(dir, worldRight).normalize();
+        }
+        sweepBitangent.cross(dir, sweepTangent).normalize();
+
+        let found = false;
+        let bestTravel = Infinity;
+
+        for (let i = 0; i < SWEEP_RAY_OFFSETS.length; i++) {
+            const [tx, ty, centerRay] = SWEEP_RAY_OFFSETS[i];
+            const radiusOffset = centerRay ? 0 : this.radius;
+            const rayExtension = centerRay ? this.radius : 0;
+
+            sweepOrigin.copy(position);
+            if (!centerRay) {
+                sweepOrigin.add(v.copy(sweepTangent).mulScalar(tx * radiusOffset));
+                sweepOrigin.add(v.copy(sweepBitangent).mulScalar(ty * radiusOffset));
+            }
+
+            const hit = this.collision!.queryRay(
+                sweepOrigin.x, sweepOrigin.y, sweepOrigin.z,
+                dir.x, dir.y, dir.z,
+                distance + rayExtension + COLLISION_SKIN
+            );
+            if (!hit) {
+                continue;
+            }
+
+            const hx = hit.x - sweepOrigin.x;
+            const hy = hit.y - sweepOrigin.y;
+            const hz = hit.z - sweepOrigin.z;
+            const hitDistance = Math.max(0, hx * dir.x + hy * dir.y + hz * dir.z);
+            const clearance = centerRay ? this.radius : 0;
+            const travel = math.clamp(hitDistance - clearance - COLLISION_SKIN, 0, distance);
+            if (travel >= bestTravel) {
+                continue;
+            }
+
+            const surfaceNormal = this.collision!.querySurfaceNormal(
+                hit.x, hit.y, hit.z,
+                dir.x, dir.y, dir.z
+            );
+
+            found = true;
+            bestTravel = travel;
+            out.x = hit.x;
+            out.y = hit.y;
+            out.z = hit.z;
+            out.nx = surfaceNormal.nx;
+            out.ny = surfaceNormal.ny;
+            out.nz = surfaceNormal.nz;
+            out.travel = travel;
+        }
+
+        return found;
     }
 
     private _resolveSphere(position: Vec3, push: Vec3): boolean {

--- a/src/cameras/target-navigation.ts
+++ b/src/cameras/target-navigation.ts
@@ -1,0 +1,96 @@
+import { math } from 'playcanvas';
+
+const RAD_TO_DEG = 180 / Math.PI;
+
+const shortestAngle = (angle: number) => ((angle % 360) + 540) % 360 - 180;
+
+const smoothstep = (edge0: number, edge1: number, value: number) => {
+    const t = math.clamp((value - edge0) / (edge1 - edge0), 0, 1);
+    return t * t * (3 - 2 * t);
+};
+
+const approach = (value: number, target: number, maxDelta: number) => {
+    if (value < target) {
+        return Math.min(target, value + maxDelta);
+    }
+
+    return Math.max(target, value - maxDelta);
+};
+
+const smoothTurnRate = (
+    currentRate: number,
+    angleDiff: number,
+    maxTurnRate: number,
+    turnGain: number,
+    dt: number
+) => {
+    if (dt <= 0) {
+        return currentRate;
+    }
+
+    const desiredRate = math.clamp(angleDiff * turnGain, -maxTurnRate, maxTurnRate);
+    const smoothing = 1 - Math.exp(-4 * turnGain * dt);
+    return currentRate + (desiredRate - currentRate) * smoothing;
+};
+
+const clampTurnStep = (rate: number, remaining: number, dt: number) => {
+    const step = rate * dt;
+    if (Math.abs(remaining) < 1e-4) {
+        return 0;
+    }
+
+    return Math.sign(step) === Math.sign(remaining) && Math.abs(step) > Math.abs(remaining) ?
+        remaining :
+        step;
+};
+
+const getYawToTarget = (dx: number, dz: number) => Math.atan2(-dx, -dz) * RAD_TO_DEG;
+
+const getYawDiffToTarget = (dx: number, dz: number, yaw: number) => {
+    return shortestAngle(getYawToTarget(dx, dz) - yaw);
+};
+
+const getPitchToDirection = (dirY: number) => {
+    return Math.asin(math.clamp(dirY, -1, 1)) * RAD_TO_DEG;
+};
+
+class ProgressTracker {
+    private _blockedTime = 0;
+
+    private _prevDist = Infinity;
+
+    reset() {
+        this._blockedTime = 0;
+        this._prevDist = Infinity;
+    }
+
+    update(distance: number, dt: number, blockedSpeed: number, blockedDuration: number, active = true) {
+        if (active && this._prevDist !== Infinity && dt > 0) {
+            const speed = (this._prevDist - distance) / dt;
+            if (speed < blockedSpeed) {
+                this._blockedTime += dt;
+                if (this._blockedTime >= blockedDuration) {
+                    this._prevDist = distance;
+                    return true;
+                }
+            } else {
+                this._blockedTime = 0;
+            }
+        }
+
+        this._prevDist = distance;
+        return false;
+    }
+}
+
+export {
+    ProgressTracker,
+    approach,
+    clampTurnStep,
+    getPitchToDirection,
+    getYawDiffToTarget,
+    getYawToTarget,
+    shortestAngle,
+    smoothTurnRate,
+    smoothstep
+};

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -1,7 +1,8 @@
-import { math, Vec3, Quat } from 'playcanvas';
+import { math, Vec3 } from 'playcanvas';
 
 import type { Collision, PushOut } from '../collision';
 import type { CameraFrame, Camera, CameraController } from './camera';
+import { applyFrameRotation, setBasisOffset, setYawBasis } from './camera-utils';
 import { damp } from '../core/math';
 
 const FIXED_DT = 1 / 60;
@@ -20,7 +21,6 @@ const right = new Vec3();
 const moveStep = [0, 0, 0];
 
 const offset = new Vec3();
-const rotation = new Quat();
 const spawnProbe = new Vec3();
 
 /**
@@ -170,8 +170,7 @@ class WalkController implements CameraController {
         const { move, rotate } = inputFrame.read();
 
         // apply rotation at display rate for responsive mouse look
-        this._angles.add(v.set(-rotate[1], -rotate[0], 0));
-        this._angles.x = math.clamp(this._angles.x, -90, 90);
+        applyFrameRotation(this._angles, rotate);
 
         // accumulate movement input so frames without a physics step don't lose input
         this._pendingMove[0] += move[0];
@@ -247,12 +246,8 @@ class WalkController implements CameraController {
         }
 
         // move
-        rotation.setFromEulerAngles(0, this._angles.y, 0);
-        rotation.transformVector(Vec3.FORWARD, forward);
-        rotation.transformVector(Vec3.RIGHT, right);
-        offset.set(0, 0, 0);
-        offset.add(forward.mulScalar(move[2]));
-        offset.add(right.mulScalar(move[0]));
+        setYawBasis(this._angles.y, forward, right);
+        setBasisOffset(offset, move[0], 0, move[2], forward, right, Vec3.UP);
         this._velocity.add(offset.mulScalar(this._grounded ? this.moveGroundSpeed : this.moveAirSpeed));
 
         const dampFactor = this._grounded ? this.velocityDampingGround : this.velocityDampingAir;

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -9,6 +9,7 @@ const FIXED_DT = 1 / 60;
 const MAX_SUBSTEPS = 10;
 const SPAWN_HIT_EPSILON = 1e-3;
 const SPAWN_SEARCH_MIN_STEP = 0.05;
+const SPAWN_SEARCH_MAX_STEPS = 128;
 
 /** Pre-allocated push-out vector for capsule collision */
 const out: PushOut = { x: 0, y: 0, z: 0 };
@@ -153,6 +154,7 @@ class WalkController implements CameraController {
     onEnter(camera: Camera): void {
         this.goto(camera);
         if (this.collision) {
+            this._hasSpawn = false;
             if (this._findSpawnPosition(camera.position, spawnProbe)) {
                 this._position.copy(spawnProbe);
                 this._grounded = true;
@@ -364,7 +366,12 @@ class WalkController implements CameraController {
      * @returns True if a spawn position was found.
      */
     private _searchSpawnGround(pos: Vec3, direction: -1 | 1, outPos: Vec3): boolean {
-        const step = Math.max(this.capsuleRadius, this.hoverHeight, SPAWN_SEARCH_MIN_STEP);
+        const step = Math.max(
+            this.capsuleRadius,
+            this.hoverHeight,
+            SPAWN_SEARCH_MIN_STEP,
+            this.spawnSearchRange / SPAWN_SEARCH_MAX_STEPS
+        );
         const endY = pos.y + direction * this.spawnSearchRange;
 
         for (let y = pos.y + direction * step; direction < 0 ? y >= endY : y <= endY; y += direction * step) {

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -6,7 +6,8 @@ import { damp } from '../core/math';
 
 const FIXED_DT = 1 / 60;
 const MAX_SUBSTEPS = 10;
-const SURFACE_NORMAL_THRESHOLD = 0.5;
+const SPAWN_HIT_EPSILON = 1e-3;
+const SPAWN_SEARCH_MIN_STEP = 0.05;
 
 /** Pre-allocated push-out vector for capsule collision */
 const out: PushOut = { x: 0, y: 0, z: 0 };
@@ -20,8 +21,7 @@ const moveStep = [0, 0, 0];
 
 const offset = new Vec3();
 const rotation = new Quat();
-
-type SpawnAnchor = 'eye' | 'floor' | 'ceiling';
+const spawnProbe = new Vec3();
 
 /**
  * First-person camera controller with spring-damper suspension over voxel terrain.
@@ -119,6 +119,11 @@ class WalkController implements CameraController {
      */
     groundProbeRange = 1.0;
 
+    /**
+     * Maximum vertical raycast distance to search for walk spawn ground.
+     */
+    spawnSearchRange = 1000;
+
     private _position = new Vec3();
 
     private _prevPosition = new Vec3();
@@ -140,24 +145,12 @@ class WalkController implements CameraController {
     onEnter(camera: Camera): void {
         this.goto(camera);
         if (this.collision) {
-            const spawnAnchor = this._queryCapsule(this._position) ? this._findSpawnAnchor(camera.position) : 'eye';
-
-            if (spawnAnchor === 'floor') {
-                this._position.y = camera.position.y + this.eyeHeight;
-            } else if (spawnAnchor === 'ceiling') {
-                this._position.y = camera.position.y - (this.capsuleHeight - this.eyeHeight);
-            }
-
-            this._resolveSpawnCollision();
-
-            const groundY = this._probeGround(this._position);
+            const groundY = this._findSpawnGround(camera.position);
             if (groundY !== null) {
+                this._position.y = this._getEyeYFromGround(groundY);
                 this._grounded = true;
                 this._velocity.y = 0;
-
-                if (spawnAnchor === 'eye') {
-                    this._position.y = groundY + this.hoverHeight + this.eyeHeight;
-                }
+                this._resolveSpawnCollision();
             }
 
             this._prevPosition.copy(this._position);
@@ -305,39 +298,86 @@ class WalkController implements CameraController {
     }
 
     /**
-     * Detect whether the incoming camera position is actually a floor or ceiling
-     * surface point rather than an eye position.
+     * Find a ground height for spawning into walk mode. Prefer ground directly
+     * below the camera; if that is not usable, search down and then up for the
+     * first clear walk placement with ground below it.
      *
      * @param pos - Incoming camera position.
-     * @returns Spawn anchor for interpreting the camera position.
+     * @returns Ground height to spawn on, or null to keep the camera position.
      */
-    private _findSpawnAnchor(pos: Vec3): SpawnAnchor {
-        const range = this.capsuleRadius + this.hoverHeight;
-        const collision = this.collision!;
-        let floorDist = Infinity;
-        let ceilingDist = Infinity;
+    private _findSpawnGround(pos: Vec3): number | null {
+        const groundY = this._findClearSpawnGroundBelow(pos, this.spawnSearchRange, !this._isInsideSolid(pos));
+        if (groundY !== null) {
+            return groundY;
+        }
 
-        const floorHit = collision.queryRay(pos.x, pos.y, pos.z, 0, -1, 0, range);
-        if (floorHit) {
-            const normal = collision.querySurfaceNormal(floorHit.x, floorHit.y, floorHit.z, 0, -1, 0);
-            if (normal.ny > SURFACE_NORMAL_THRESHOLD) {
-                floorDist = Math.abs(pos.y - floorHit.y);
+        return this._searchSpawnGround(pos, -1) ?? this._searchSpawnGround(pos, 1);
+    }
+
+    /**
+     * Search vertically for a clear walk spawn placement with ground below it.
+     *
+     * @param pos - Starting position.
+     * @param direction - Vertical search direction: -1 down, 1 up.
+     * @returns Ground height to spawn on, or null if none was found.
+     */
+    private _searchSpawnGround(pos: Vec3, direction: -1 | 1): number | null {
+        const step = Math.max(this.capsuleRadius, this.hoverHeight, SPAWN_SEARCH_MIN_STEP);
+        const endY = pos.y + direction * this.spawnSearchRange;
+
+        for (let y = pos.y + direction * step; direction < 0 ? y >= endY : y <= endY; y += direction * step) {
+            spawnProbe.set(pos.x, y, pos.z);
+
+            const groundY = this._findClearSpawnGroundBelow(spawnProbe, this.spawnSearchRange, false);
+            if (groundY !== null) {
+                return groundY;
             }
         }
 
-        const ceilingHit = collision.queryRay(pos.x, pos.y, pos.z, 0, 1, 0, range);
-        if (ceilingHit) {
-            const normal = collision.querySurfaceNormal(ceilingHit.x, ceilingHit.y, ceilingHit.z, 0, 1, 0);
-            if (normal.ny < -SURFACE_NORMAL_THRESHOLD) {
-                ceilingDist = Math.abs(ceilingHit.y - pos.y);
-            }
+        return null;
+    }
+
+    /**
+     * Find the first collision surface below a point that can hold a clear walk
+     * capsule.
+     *
+     * @param pos - Ray origin.
+     * @param range - Maximum ray distance.
+     * @param allowInitialHit - Whether a hit at the ray origin is valid.
+     * @returns Y coordinate of the ground hit, or null if no ground was found.
+     */
+    private _findClearSpawnGroundBelow(pos: Vec3, range: number, allowInitialHit: boolean): number | null {
+        const hit = this.collision!.queryRay(pos.x, pos.y, pos.z, 0, -1, 0, range);
+        if (!hit) {
+            return null;
         }
 
-        if (floorDist === Infinity && ceilingDist === Infinity) {
-            return 'eye';
+        if (!allowInitialHit && Math.abs(pos.y - hit.y) <= SPAWN_HIT_EPSILON) {
+            return null;
         }
 
-        return floorDist <= ceilingDist ? 'floor' : 'ceiling';
+        spawnProbe.set(pos.x, this._getEyeYFromGround(hit.y), pos.z);
+        return this._queryCapsule(spawnProbe) ? null : hit.y;
+    }
+
+    /**
+     * Convert a ground height to the walk controller's eye position.
+     *
+     * @param groundY - Ground surface height.
+     * @returns Eye position Y.
+     */
+    private _getEyeYFromGround(groundY: number): number {
+        return groundY + this.hoverHeight + this.eyeHeight;
+    }
+
+    /**
+     * Test whether the incoming camera point starts inside solid collision.
+     *
+     * @param pos - Point to test.
+     * @returns True if the point overlaps solid collision.
+     */
+    private _isInsideSolid(pos: Vec3): boolean {
+        return this.collision!.querySphere(pos.x, pos.y, pos.z, SPAWN_HIT_EPSILON, out);
     }
 
     /**

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -153,9 +153,8 @@ class WalkController implements CameraController {
     onEnter(camera: Camera): void {
         this.goto(camera);
         if (this.collision) {
-            const groundY = this._findSpawnGround(camera.position);
-            if (groundY !== null) {
-                this._position.y = this._getEyeYFromGround(groundY);
+            if (this._findSpawnPosition(camera.position, spawnProbe)) {
+                this._position.copy(spawnProbe);
                 this._grounded = true;
                 this._velocity.y = 0;
                 this._resolveSpawnCollision();
@@ -338,22 +337,22 @@ class WalkController implements CameraController {
     }
 
     /**
-     * Find a ground height for spawning into walk mode. Prefer ground directly
+     * Find an eye position for spawning into walk mode. Prefer ground directly
      * below the camera; if that is not usable, search down and then up for the
      * first clear walk placement with ground below it.
      *
      * @param pos - Incoming camera position.
-     * @returns Ground height to spawn on, or null to keep the camera position.
+     * @param outPos - Receives the resolved eye position.
+     * @returns True if a spawn position was found.
      */
-    private _findSpawnGround(pos: Vec3): number | null {
+    private _findSpawnPosition(pos: Vec3, outPos: Vec3): boolean {
         const insideSolid = this._isInsideSolid(pos);
 
-        const groundY = this._findClearSpawnGroundBelow(pos, this.spawnSearchRange, !insideSolid);
-        if (groundY !== null) {
-            return groundY;
+        if (this._findClearSpawnGroundBelow(pos, this.spawnSearchRange, !insideSolid, outPos)) {
+            return true;
         }
 
-        return this._searchSpawnGround(pos, -1) ?? this._searchSpawnGround(pos, 1);
+        return this._searchSpawnGround(pos, -1, outPos) || this._searchSpawnGround(pos, 1, outPos);
     }
 
     /**
@@ -361,22 +360,22 @@ class WalkController implements CameraController {
      *
      * @param pos - Starting position.
      * @param direction - Vertical search direction: -1 down, 1 up.
-     * @returns Ground height to spawn on, or null if none was found.
+     * @param outPos - Receives the resolved eye position.
+     * @returns True if a spawn position was found.
      */
-    private _searchSpawnGround(pos: Vec3, direction: -1 | 1): number | null {
+    private _searchSpawnGround(pos: Vec3, direction: -1 | 1, outPos: Vec3): boolean {
         const step = Math.max(this.capsuleRadius, this.hoverHeight, SPAWN_SEARCH_MIN_STEP);
         const endY = pos.y + direction * this.spawnSearchRange;
 
         for (let y = pos.y + direction * step; direction < 0 ? y >= endY : y <= endY; y += direction * step) {
             spawnProbe.set(pos.x, y, pos.z);
 
-            const groundY = this._findClearSpawnGroundBelow(spawnProbe, this.spawnSearchRange, false);
-            if (groundY !== null) {
-                return groundY;
+            if (this._findClearSpawnGroundBelow(spawnProbe, this.spawnSearchRange, false, outPos)) {
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
     /**
@@ -386,23 +385,24 @@ class WalkController implements CameraController {
      * @param pos - Ray origin.
      * @param range - Maximum ray distance.
      * @param allowInitialHit - Whether a hit at the ray origin is valid.
-     * @returns Y coordinate of the ground hit, or null if no ground was found.
+     * @param outPos - Receives the resolved eye position.
+     * @returns True if a usable ground position was found.
      */
-    private _findClearSpawnGroundBelow(pos: Vec3, range: number, allowInitialHit: boolean): number | null {
+    private _findClearSpawnGroundBelow(pos: Vec3, range: number, allowInitialHit: boolean, outPos: Vec3): boolean {
         const hit = this.collision!.queryRay(pos.x, pos.y, pos.z, 0, -1, 0, range);
         if (!hit) {
-            return null;
+            return false;
         }
 
         if (!allowInitialHit && Math.abs(pos.y - hit.y) <= SPAWN_HIT_EPSILON) {
-            return null;
+            return false;
         }
 
-        spawnProbe.set(pos.x, this._getEyeYFromGround(hit.y), pos.z);
-        const clear = !this._queryCapsule(spawnProbe);
-        const accepted = clear || this._resolveSpawnCandidate(spawnProbe);
+        outPos.set(pos.x, this._getEyeYFromGround(hit.y), pos.z);
+        const clear = !this._queryCapsule(outPos);
+        const accepted = clear || this._resolveSpawnCandidate(outPos);
 
-        return accepted ? hit.y : null;
+        return accepted;
     }
 
     /**

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -130,6 +130,10 @@ class WalkController implements CameraController {
 
     private _angles = new Vec3();
 
+    private _spawnPosition = new Vec3();
+
+    private _spawnAngles = new Vec3();
+
     private _velocity = new Vec3();
 
     private _pendingMove = [0, 0, 0];
@@ -141,6 +145,10 @@ class WalkController implements CameraController {
     private _jumping = false;
 
     private _jumpHeld = false;
+
+    private _spawnGrounded = false;
+
+    private _hasSpawn = false;
 
     onEnter(camera: Camera): void {
         this.goto(camera);
@@ -154,6 +162,7 @@ class WalkController implements CameraController {
             }
 
             this._prevPosition.copy(this._position);
+            this._storeSpawn();
         }
     }
 
@@ -275,9 +284,45 @@ class WalkController implements CameraController {
         this._angles.set(camera.angles.x, camera.angles.y, 0);
 
         // reset velocity and state
+        this._resetMotion();
+    }
+
+    /**
+     * Reset the controller to the spawn pose captured on the last walk-mode entry.
+     *
+     * @param camera - Camera state to update with the spawn pose.
+     * @returns True if a spawn pose was available.
+     */
+    resetToSpawn(camera: Camera): boolean {
+        if (!this._hasSpawn) {
+            return false;
+        }
+
+        this._position.copy(this._spawnPosition);
+        this._prevPosition.copy(this._position);
+        this._angles.copy(this._spawnAngles);
+        this._resetMotion();
+        this._grounded = this._spawnGrounded;
+
+        camera.position.copy(this._position);
+        camera.angles.copy(this._angles);
+        camera.fov = this.fov;
+
+        return true;
+    }
+
+    private _storeSpawn() {
+        this._spawnPosition.copy(this._position);
+        this._spawnAngles.copy(this._angles);
+        this._spawnGrounded = this._grounded;
+        this._hasSpawn = true;
+    }
+
+    private _resetMotion() {
         this._velocity.set(0, 0, 0);
         this._grounded = false;
         this._jumping = false;
+        this._jumpHeld = false;
         this._pendingMove[0] = 0;
         this._pendingMove[1] = 0;
         this._pendingMove[2] = 0;
@@ -306,7 +351,9 @@ class WalkController implements CameraController {
      * @returns Ground height to spawn on, or null to keep the camera position.
      */
     private _findSpawnGround(pos: Vec3): number | null {
-        const groundY = this._findClearSpawnGroundBelow(pos, this.spawnSearchRange, !this._isInsideSolid(pos));
+        const insideSolid = this._isInsideSolid(pos);
+
+        const groundY = this._findClearSpawnGroundBelow(pos, this.spawnSearchRange, !insideSolid);
         if (groundY !== null) {
             return groundY;
         }
@@ -357,7 +404,10 @@ class WalkController implements CameraController {
         }
 
         spawnProbe.set(pos.x, this._getEyeYFromGround(hit.y), pos.z);
-        return this._queryCapsule(spawnProbe) ? null : hit.y;
+        const clear = !this._queryCapsule(spawnProbe);
+        const accepted = clear || this._resolveSpawnCandidate(spawnProbe);
+
+        return accepted ? hit.y : null;
     }
 
     /**
@@ -378,6 +428,54 @@ class WalkController implements CameraController {
      */
     private _isInsideSolid(pos: Vec3): boolean {
         return this.collision!.querySphere(pos.x, pos.y, pos.z, SPAWN_HIT_EPSILON, out);
+    }
+
+    /**
+     * Try to resolve a spawn candidate and verify it remains supported by ground.
+     *
+     * @param pos - Candidate eye position to resolve in place.
+     * @returns True if the candidate can be made clear and still stand on ground.
+     */
+    private _resolveSpawnCandidate(pos: Vec3): boolean {
+        const startX = pos.x;
+        const startY = pos.y;
+        const startZ = pos.z;
+        const maxResolveDistance = this.capsuleRadius + this.hoverHeight;
+        const maxResolveDistanceSq = maxResolveDistance * maxResolveDistance;
+
+        for (let i = 0; i < 100; i++) {
+            if (!this._queryCapsule(pos)) {
+                return this._hasSpawnGroundSupport(pos);
+            }
+
+            pos.add(v.set(out.x, out.y, out.z));
+
+            const dx = pos.x - startX;
+            const dy = pos.y - startY;
+            const dz = pos.z - startZ;
+            if (dx * dx + dy * dy + dz * dz > maxResolveDistanceSq) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Verify the resolved spawn candidate is still standing close to ground.
+     *
+     * @param pos - Resolved candidate eye position.
+     * @returns True if ground support is still valid.
+     */
+    private _hasSpawnGroundSupport(pos: Vec3): boolean {
+        const groundY = this._probeGround(pos);
+        if (groundY === null) {
+            return false;
+        }
+
+        const clearance = pos.y - this.eyeHeight - groundY;
+        return clearance >= -SPAWN_HIT_EPSILON &&
+            clearance <= this.hoverHeight + this.capsuleRadius + SPAWN_HIT_EPSILON;
     }
 
     /**

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -6,6 +6,7 @@ import { damp } from '../core/math';
 
 const FIXED_DT = 1 / 60;
 const MAX_SUBSTEPS = 10;
+const SURFACE_NORMAL_THRESHOLD = 0.5;
 
 /** Pre-allocated push-out vector for capsule collision */
 const out: PushOut = { x: 0, y: 0, z: 0 };
@@ -19,6 +20,8 @@ const moveStep = [0, 0, 0];
 
 const offset = new Vec3();
 const rotation = new Quat();
+
+type SpawnAnchor = 'eye' | 'floor' | 'ceiling';
 
 /**
  * First-person camera controller with spring-damper suspension over voxel terrain.
@@ -137,16 +140,27 @@ class WalkController implements CameraController {
     onEnter(camera: Camera): void {
         this.goto(camera);
         if (this.collision) {
+            const spawnAnchor = this._queryCapsule(this._position) ? this._findSpawnAnchor(camera.position) : 'eye';
+
+            if (spawnAnchor === 'floor') {
+                this._position.y = camera.position.y + this.eyeHeight;
+            } else if (spawnAnchor === 'ceiling') {
+                this._position.y = camera.position.y - (this.capsuleHeight - this.eyeHeight);
+            }
+
             this._resolveSpawnCollision();
-            this._prevPosition.copy(this._position);
 
             const groundY = this._probeGround(this._position);
             if (groundY !== null) {
                 this._grounded = true;
                 this._velocity.y = 0;
-                this._position.y = groundY + this.hoverHeight + this.eyeHeight;
-                this._prevPosition.copy(this._position);
+
+                if (spawnAnchor === 'eye') {
+                    this._position.y = groundY + this.hoverHeight + this.eyeHeight;
+                }
             }
+
+            this._prevPosition.copy(this._position);
         }
     }
 
@@ -278,22 +292,65 @@ class WalkController implements CameraController {
     }
 
     /**
-     * Push the capsule upward until it clears solid geometry, up to a maximum of
-     * 100 iterations. Only used at spawn time to handle the case where walk mode
-     * activates inside a solid region. Per-frame collision resolution is unaffected,
-     * avoiding the ceiling launch bug.
+     * Resolve the capsule out of solid geometry at spawn time. This is only used
+     * when walk mode activates inside collision.
      */
     private _resolveSpawnCollision() {
-        const half = this.capsuleHeight * 0.5 - this.capsuleRadius;
-        const minStep = this.capsuleRadius;
-
         for (let i = 0; i < 100; i++) {
-            const center = this._position.y - this.eyeHeight + this.capsuleHeight * 0.5;
-            if (!this.collision!.queryCapsule(this._position.x, center, this._position.z, half, this.capsuleRadius, out)) {
+            if (!this._queryCapsule(this._position)) {
                 break;
             }
-            this._position.y += Math.max(out.y, minStep);
+            this._position.add(v.set(out.x, out.y, out.z));
         }
+    }
+
+    /**
+     * Detect whether the incoming camera position is actually a floor or ceiling
+     * surface point rather than an eye position.
+     *
+     * @param pos - Incoming camera position.
+     * @returns Spawn anchor for interpreting the camera position.
+     */
+    private _findSpawnAnchor(pos: Vec3): SpawnAnchor {
+        const range = this.capsuleRadius + this.hoverHeight;
+        const collision = this.collision!;
+        let floorDist = Infinity;
+        let ceilingDist = Infinity;
+
+        const floorHit = collision.queryRay(pos.x, pos.y, pos.z, 0, -1, 0, range);
+        if (floorHit) {
+            const normal = collision.querySurfaceNormal(floorHit.x, floorHit.y, floorHit.z, 0, -1, 0);
+            if (normal.ny > SURFACE_NORMAL_THRESHOLD) {
+                floorDist = Math.abs(pos.y - floorHit.y);
+            }
+        }
+
+        const ceilingHit = collision.queryRay(pos.x, pos.y, pos.z, 0, 1, 0, range);
+        if (ceilingHit) {
+            const normal = collision.querySurfaceNormal(ceilingHit.x, ceilingHit.y, ceilingHit.z, 0, 1, 0);
+            if (normal.ny < -SURFACE_NORMAL_THRESHOLD) {
+                ceilingDist = Math.abs(ceilingHit.y - pos.y);
+            }
+        }
+
+        if (floorDist === Infinity && ceilingDist === Infinity) {
+            return 'eye';
+        }
+
+        return floorDist <= ceilingDist ? 'floor' : 'ceiling';
+    }
+
+    /**
+     * Query the current walk capsule at the supplied eye position.
+     *
+     * @param pos - Eye position in PlayCanvas world space.
+     * @returns True if the capsule overlaps collision.
+     */
+    private _queryCapsule(pos: Vec3): boolean {
+        const half = this.capsuleHeight * 0.5 - this.capsuleRadius;
+        const center = pos.y - this.eyeHeight + this.capsuleHeight * 0.5;
+
+        return this.collision!.queryCapsule(pos.x, center, pos.z, half, this.capsuleRadius, out);
     }
 
     /**

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -131,9 +131,13 @@ class WalkController implements CameraController {
 
     private _angles = new Vec3();
 
+    private _distance = 1;
+
     private _spawnPosition = new Vec3();
 
     private _spawnAngles = new Vec3();
+
+    private _spawnDistance = 1;
 
     private _velocity = new Vec3();
 
@@ -202,6 +206,7 @@ class WalkController implements CameraController {
         const alpha = this._accumulator / FIXED_DT;
         camera.position.lerp(this._prevPosition, this._position, alpha);
         camera.angles.set(this._angles.x, this._angles.y, 0);
+        camera.distance = this._distance;
         camera.fov = this.fov;
     }
 
@@ -278,6 +283,7 @@ class WalkController implements CameraController {
 
         // angles (clamp pitch to avoid gimbal lock)
         this._angles.set(camera.angles.x, camera.angles.y, 0);
+        this._distance = camera.distance;
 
         // reset velocity and state
         this._resetMotion();
@@ -297,11 +303,13 @@ class WalkController implements CameraController {
         this._position.copy(this._spawnPosition);
         this._prevPosition.copy(this._position);
         this._angles.copy(this._spawnAngles);
+        this._distance = this._spawnDistance;
         this._resetMotion();
         this._grounded = this._spawnGrounded;
 
         camera.position.copy(this._position);
         camera.angles.copy(this._angles);
+        camera.distance = this._distance;
         camera.fov = this.fov;
 
         return true;
@@ -310,6 +318,7 @@ class WalkController implements CameraController {
     private _storeSpawn() {
         this._spawnPosition.copy(this._position);
         this._spawnAngles.copy(this._angles);
+        this._spawnDistance = this._distance;
         this._spawnGrounded = this._grounded;
         this._hasSpawn = true;
     }

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -24,11 +24,11 @@ const offset = new Vec3();
 const spawnProbe = new Vec3();
 
 /**
- * First-person camera controller with spring-damper suspension over voxel terrain.
+ * First-person camera controller with spring-damper suspension over collision terrain.
  *
  * Movement is constrained to the horizontal plane (XZ) relative to the camera yaw.
  * Vertical positioning uses a spring-damper system that hovers the capsule above the
- * voxel surface, filtering out terrain noise for smooth camera motion. Capsule
+ * collision surface, filtering out terrain noise for smooth camera motion. Capsule
  * collision handles walls and obstacles. When airborne, normal gravity applies.
  */
 class WalkController implements CameraController {
@@ -99,7 +99,7 @@ class WalkController implements CameraController {
 
     /**
      * Target clearance from capsule bottom to ground surface in meters.
-     * The capsule hovers this far above terrain to avoid bouncing on noisy voxels.
+     * The capsule hovers this far above terrain to avoid bouncing on noisy surfaces.
      */
     hoverHeight = 0.2;
 
@@ -489,7 +489,7 @@ class WalkController implements CameraController {
     /**
      * Cast multiple rays downward to find the average ground surface height.
      * Uses 5 rays (center + 4 cardinal at capsule radius) to spatially filter
-     * noisy voxel heights, giving the spring a smoother target.
+     * noisy collision heights, giving the spring a smoother target.
      *
      * @param pos - Eye position in PlayCanvas world space.
      * @returns Average ground surface Y in PlayCanvas space, or null if no ground found.

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -158,10 +158,10 @@ class WalkController implements CameraController {
                 this._grounded = true;
                 this._velocity.y = 0;
                 this._resolveSpawnCollision();
+                this._storeSpawn();
             }
 
             this._prevPosition.copy(this._position);
-            this._storeSpawn();
         }
     }
 

--- a/src/cameras/walk-source.ts
+++ b/src/cameras/walk-source.ts
@@ -1,8 +1,7 @@
 import { Vec3 } from 'playcanvas';
 
 import type { CameraFrame } from './camera';
-
-const RAD_TO_DEG = 180 / Math.PI;
+import { ProgressTracker, clampTurnStep, getYawDiffToTarget, smoothTurnRate } from './target-navigation';
 
 /** XZ distance below which the walker considers itself arrived */
 const ARRIVAL_DIST = 0.5;
@@ -49,9 +48,7 @@ class WalkSource {
 
     private _yawRate = 0;
 
-    private _blockedTime = 0;
-
-    private _prevDist = Infinity;
+    private _progress = new ProgressTracker();
 
     get isWalking(): boolean {
         return this._target !== null;
@@ -67,8 +64,7 @@ class WalkSource {
             this._target = new Vec3();
         }
         this._target.copy(target);
-        this._blockedTime = 0;
-        this._prevDist = Infinity;
+        this._progress.reset();
     }
 
     /**
@@ -78,7 +74,7 @@ class WalkSource {
         if (this._target) {
             this._target = null;
             this._yawRate = 0;
-            this._blockedTime = 0;
+            this._progress.reset();
             this.onComplete?.();
         }
     }
@@ -108,31 +104,19 @@ class WalkSource {
         }
 
         // blocked detection: compare with previous frame's distance
-        if (this._prevDist !== Infinity && dt > 0) {
-            const speed = (this._prevDist - xzDist) / dt;
-            if (speed < BLOCKED_SPEED) {
-                this._blockedTime += dt;
-                if (this._blockedTime >= BLOCKED_DURATION) {
-                    this.cancelWalk();
-                    return;
-                }
-            } else {
-                this._blockedTime = 0;
-            }
+        if (this._progress.update(xzDist, dt, BLOCKED_SPEED, BLOCKED_DURATION)) {
+            this.cancelWalk();
+            return;
         }
-        this._prevDist = xzDist;
 
         // yaw toward target with smoothed turn rate
-        const targetYaw = Math.atan2(-dx, -dz) * RAD_TO_DEG;
-        let yawDiff = targetYaw - cameraAngles.y;
-        yawDiff = ((yawDiff % 360) + 540) % 360 - 180;
-
-        const desiredRate = Math.max(-this.maxTurnRate, Math.min(yawDiff * this.turnGain, this.maxTurnRate));
-        const smoothing = 1 - Math.exp(-4 * this.turnGain * dt);
-        this._yawRate += (desiredRate - this._yawRate) * smoothing;
+        const yawDiff = getYawDiffToTarget(dx, dz, cameraAngles.y);
+        this._yawRate = smoothTurnRate(this._yawRate, yawDiff, this.maxTurnRate, this.turnGain, dt);
+        const yawStep = clampTurnStep(this._yawRate, yawDiff, dt);
+        this._yawRate = dt > 0 ? yawStep / dt : this._yawRate;
 
         // WalkController applies: _angles.y += -rotate[0]
-        frame.deltas.rotate.append([-(this._yawRate * dt), 0, 0]);
+        frame.deltas.rotate.append([-yawStep, 0, 0]);
 
         // scale forward speed by alignment: turn in place first, then accelerate
         const alignment = Math.max(0, Math.cos(yawDiff * Math.PI / 180));

--- a/src/index.html
+++ b/src/index.html
@@ -229,7 +229,7 @@
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Set Focus</span>
-                                <span class="control-key">Double Click</span>
+                                <span class="control-key">Click</span>
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Frame Scene</span>
@@ -241,6 +241,10 @@
                             </div>
                             <div class="control-spacer"></div>
                             <h1>Fly Mode</h1>
+                            <div class="control-item">
+                                <span class="control-action">Fly To</span>
+                                <span class="control-key">Click</span>
+                            </div>
                             <div class="control-item">
                                 <span class="control-action">Look Around</span>
                                 <span class="control-key">Click + Drag</span>
@@ -323,11 +327,15 @@
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Set Focus</span>
-                                <span class="control-key">Double Tap</span>
+                                <span class="control-key">Tap</span>
                             </div>
                             <div class="control-spacer"></div>
                             <h1>Fly Mode</h1>
                             <div id="touchFlyClickToWalk">
+                                <div class="control-item">
+                                    <span class="control-action">Fly To</span>
+                                    <span class="control-key">Tap</span>
+                                </div>
                                 <div class="control-item">
                                     <span class="control-action">Look Around</span>
                                     <span class="control-key">Touch + Drag</span>

--- a/src/index.html
+++ b/src/index.html
@@ -241,7 +241,7 @@
                             </div>
                             <div class="control-spacer"></div>
                             <h1>Fly Mode</h1>
-                            <div class="control-item">
+                            <div id="desktopFlyClickToFly" class="control-item">
                                 <span class="control-action">Fly To</span>
                                 <span class="control-key">Click</span>
                             </div>

--- a/src/input-controller.ts
+++ b/src/input-controller.ts
@@ -10,6 +10,7 @@ import { KeyboardMouseDevice } from './input/devices/keyboard-mouse';
 import { TouchDevice } from './input/devices/touch';
 import { TrackpadDevice } from './input/devices/trackpad';
 import type { UpdateContext } from './input/shared';
+import type { Picker } from './picker';
 import type { Global } from './types';
 
 /**
@@ -34,7 +35,7 @@ class InputController {
 
     private _gamepad = new GamepadDevice();
 
-    private _walkInteraction = new WalkInteraction();
+    private _walkInteraction: WalkInteraction;
 
     private _pointerLock = new PointerLockManager();
 
@@ -50,8 +51,9 @@ class InputController {
         return this._walkInteraction.collision;
     }
 
-    constructor(global: Global) {
+    constructor(global: Global, picker: Picker) {
         this._global = global;
+        this._walkInteraction = new WalkInteraction(picker);
 
         const { app, events } = global;
         const canvas = app.graphicsDevice.canvas as HTMLCanvasElement;

--- a/src/input/app/mode-shortcuts.ts
+++ b/src/input/app/mode-shortcuts.ts
@@ -54,6 +54,9 @@ class ModeShortcuts {
             case 'h':
                 events.fire('inputEvent', 'toggleHelp');
                 break;
+            case 'r':
+                events.fire('inputEvent', 'reset', event);
+                break;
             default:
                 if ((event.code === 'KeyW' || event.code === 'KeyA' || event.code === 'KeyS' || event.code === 'KeyD') &&
                     state.cameraMode === 'walk' && state.inputMode === 'desktop' && !state.gamingControls) {
@@ -66,9 +69,6 @@ class ModeShortcuts {
             switch (event.key) {
                 case 'f':
                     events.fire('inputEvent', 'frame', event);
-                    break;
-                case 'r':
-                    events.fire('inputEvent', 'reset', event);
                     break;
                 case ' ':
                     events.fire('inputEvent', 'playPause', event);

--- a/src/input/app/mode-shortcuts.ts
+++ b/src/input/app/mode-shortcuts.ts
@@ -1,6 +1,15 @@
 import type { PointerLockManager } from './pointer-lock';
 import type { Global } from '../../types';
 
+const isCaptureMode = (mode: string) => mode === 'walk' || mode === 'fly';
+
+const isWasdKey = (event: KeyboardEvent) => (
+    event.code === 'KeyW' ||
+    event.code === 'KeyA' ||
+    event.code === 'KeyS' ||
+    event.code === 'KeyD'
+);
+
 /**
  * Keyboard shortcuts that switch camera mode and toggle UI affordances.
  * Listens on `window` so the user can press 1/2/3, V, G, H, F, R, Space,
@@ -17,9 +26,9 @@ class ModeShortcuts {
         const { state, events } = global;
 
         if (event.key === 'Escape') {
-            if (this._pointerLock?.recentlyExitedWalk) {
+            if (this._pointerLock?.recentlyExitedCapture) {
                 // already handled by pointerlockchange
-            } else if (state.cameraMode === 'walk' && state.gamingControls && state.inputMode === 'desktop') {
+            } else if (isCaptureMode(state.cameraMode) && state.gamingControls && state.inputMode === 'desktop') {
                 state.gamingControls = false;
             } else if (state.cameraMode === 'walk') {
                 events.fire('inputEvent', 'exitWalk', event);
@@ -58,9 +67,13 @@ class ModeShortcuts {
                 events.fire('inputEvent', 'reset', event);
                 break;
             default:
-                if ((event.code === 'KeyW' || event.code === 'KeyA' || event.code === 'KeyS' || event.code === 'KeyD') &&
-                    state.cameraMode === 'walk' && state.inputMode === 'desktop' && !state.gamingControls) {
-                    state.gamingControls = true;
+                if (isWasdKey(event) && state.inputMode === 'desktop') {
+                    if (!isCaptureMode(state.cameraMode)) {
+                        state.cameraMode = 'fly';
+                    }
+                    if (!state.gamingControls) {
+                        state.gamingControls = true;
+                    }
                 }
                 break;
         }

--- a/src/input/app/pointer-lock.ts
+++ b/src/input/app/pointer-lock.ts
@@ -1,13 +1,15 @@
 import type { Global } from '../../types';
 import type { KeyboardMouseDevice } from '../devices/keyboard-mouse';
 
+const isCaptureMode = (mode: string) => mode === 'walk' || mode === 'fly';
+
 /**
- * Manages the browser's pointer-lock API for walk-mode + gaming controls
+ * Manages the browser's pointer-lock API for first-person gaming controls
  * on desktop. Toggles in response to `cameraMode:changed` and
  * `gamingControls:changed`, and reverts state if the lock is exited or
  * rejected.
  *
- * Also exposes `recentlyExitedWalk` so the keyboard-shortcut handler can
+ * Also exposes `recentlyExitedCapture` so the keyboard-shortcut handler can
  * de-duplicate the Escape keydown that triggered the lock exit.
  */
 class PointerLockManager {
@@ -17,20 +19,20 @@ class PointerLockManager {
 
     private _keyboardMouse: KeyboardMouseDevice | null = null;
 
-    private _recentlyExitedWalk = false;
+    private _recentlyExitedCapture = false;
 
     private _onPointerLockChange = () => {
         const global = this._global;
         if (!global) return;
         const { state, events } = global;
-        if (!document.pointerLockElement && state.cameraMode === 'walk' && state.gamingControls) {
-            this._recentlyExitedWalk = true;
+        if (!document.pointerLockElement && isCaptureMode(state.cameraMode) && state.gamingControls) {
+            this._recentlyExitedCapture = true;
             requestAnimationFrame(() => {
-                this._recentlyExitedWalk = false;
+                this._recentlyExitedCapture = false;
             });
             if (state.inputMode === 'desktop') {
                 state.gamingControls = false;
-            } else {
+            } else if (state.cameraMode === 'walk') {
                 events.fire('inputEvent', 'exitWalk');
             }
         }
@@ -46,9 +48,9 @@ class PointerLockManager {
         const global = this._global;
         if (!global) return;
         const { state, events } = global;
-        if (state.inputMode === 'desktop') {
+        if (state.inputMode === 'desktop' && isCaptureMode(state.cameraMode)) {
             state.gamingControls = false;
-        } else {
+        } else if (state.cameraMode === 'walk') {
             events.fire('inputEvent', 'exitWalk');
         }
     };
@@ -56,9 +58,9 @@ class PointerLockManager {
     private _onCameraModeChanged = (value: string, prev: string) => {
         const state = this._global?.state;
         if (!state) return;
-        if (value === 'walk' && state.inputMode === 'desktop' && state.gamingControls) {
+        if (isCaptureMode(value) && state.inputMode === 'desktop' && state.gamingControls) {
             this._activate();
-        } else if (prev === 'walk') {
+        } else if (isCaptureMode(prev)) {
             this._deactivate();
         }
     };
@@ -66,7 +68,7 @@ class PointerLockManager {
     private _onGamingControlsChanged = (value: boolean) => {
         const state = this._global?.state;
         if (!state) return;
-        if (state.cameraMode === 'walk' && state.inputMode === 'desktop') {
+        if (isCaptureMode(state.cameraMode) && state.inputMode === 'desktop') {
             if (value) {
                 this._activate();
             } else {
@@ -79,7 +81,9 @@ class PointerLockManager {
         if (this._keyboardMouse) {
             (this._keyboardMouse.source as any)._pointerLock = true;
         }
-        this._canvas?.requestPointerLock();
+        if (document.pointerLockElement !== this._canvas) {
+            this._canvas?.requestPointerLock();
+        }
     }
 
     private _deactivate(): void {
@@ -91,8 +95,8 @@ class PointerLockManager {
         }
     }
 
-    get recentlyExitedWalk(): boolean {
-        return this._recentlyExitedWalk;
+    get recentlyExitedCapture(): boolean {
+        return this._recentlyExitedCapture;
     }
 
     attach(canvas: HTMLCanvasElement, global: Global, keyboardMouse: KeyboardMouseDevice): void {

--- a/src/input/app/pointer-lock.ts
+++ b/src/input/app/pointer-lock.ts
@@ -5,9 +5,8 @@ const isCaptureMode = (mode: string) => mode === 'walk' || mode === 'fly';
 
 /**
  * Manages the browser's pointer-lock API for first-person gaming controls
- * on desktop. Toggles in response to `cameraMode:changed` and
- * `gamingControls:changed`, and reverts state if the lock is exited or
- * rejected.
+ * on desktop. Toggles in response to camera mode, input mode, and
+ * gaming-controls changes, and reverts state if the lock is exited or rejected.
  *
  * Also exposes `recentlyExitedCapture` so the keyboard-shortcut handler can
  * de-duplicate the Escape keydown that triggered the lock exit.
@@ -77,6 +76,19 @@ class PointerLockManager {
         }
     };
 
+    private _onInputModeChanged = (value: string) => {
+        const state = this._global?.state;
+        if (!state || !isCaptureMode(state.cameraMode) || !state.gamingControls) {
+            return;
+        }
+
+        if (value === 'desktop') {
+            this._activate();
+        } else {
+            this._deactivate();
+        }
+    };
+
     private _activate(): void {
         if (this._keyboardMouse) {
             (this._keyboardMouse.source as any)._pointerLock = true;
@@ -108,6 +120,7 @@ class PointerLockManager {
 
         events.on('cameraMode:changed', this._onCameraModeChanged);
         events.on('gamingControls:changed', this._onGamingControlsChanged);
+        events.on('inputMode:changed', this._onInputModeChanged);
 
         document.addEventListener('pointerlockchange', this._onPointerLockChange);
         document.addEventListener('pointerlockerror', this._onPointerLockError);
@@ -118,6 +131,7 @@ class PointerLockManager {
             const { events } = this._global;
             events.off('cameraMode:changed', this._onCameraModeChanged);
             events.off('gamingControls:changed', this._onGamingControlsChanged);
+            events.off('inputMode:changed', this._onInputModeChanged);
         }
         document.removeEventListener('pointerlockchange', this._onPointerLockChange);
         document.removeEventListener('pointerlockerror', this._onPointerLockError);

--- a/src/input/app/pointer-lock.ts
+++ b/src/input/app/pointer-lock.ts
@@ -2,6 +2,9 @@ import type { Global } from '../../types';
 import type { KeyboardMouseDevice } from '../devices/keyboard-mouse';
 
 const isCaptureMode = (mode: string) => mode === 'walk' || mode === 'fly';
+const hasUserActivation = () => (
+    (navigator as Navigator & { userActivation?: { isActive: boolean } }).userActivation?.isActive === true
+);
 
 /**
  * Manages the browser's pointer-lock API for first-person gaming controls
@@ -82,10 +85,17 @@ class PointerLockManager {
             return;
         }
 
-        if (value === 'desktop') {
+        if (value === 'desktop' && hasUserActivation()) {
             this._activate();
-        } else {
+        } else if (value !== 'desktop') {
             this._deactivate();
+        }
+    };
+
+    private _onPointerDown = () => {
+        const state = this._global?.state;
+        if (state && state.inputMode === 'desktop' && isCaptureMode(state.cameraMode) && state.gamingControls) {
+            this._activate();
         }
     };
 
@@ -122,6 +132,7 @@ class PointerLockManager {
         events.on('gamingControls:changed', this._onGamingControlsChanged);
         events.on('inputMode:changed', this._onInputModeChanged);
 
+        canvas.addEventListener('pointerdown', this._onPointerDown);
         document.addEventListener('pointerlockchange', this._onPointerLockChange);
         document.addEventListener('pointerlockerror', this._onPointerLockError);
     }
@@ -133,6 +144,7 @@ class PointerLockManager {
             events.off('gamingControls:changed', this._onGamingControlsChanged);
             events.off('inputMode:changed', this._onInputModeChanged);
         }
+        this._canvas?.removeEventListener('pointerdown', this._onPointerDown);
         document.removeEventListener('pointerlockchange', this._onPointerLockChange);
         document.removeEventListener('pointerlockerror', this._onPointerLockError);
         this._canvas = null;

--- a/src/input/app/walk-interaction.ts
+++ b/src/input/app/walk-interaction.ts
@@ -1,7 +1,7 @@
 import { Vec3 } from 'playcanvas';
 
 import type { Collision } from '../../collision';
-import { Picker } from '../../picker';
+import type { Picker } from '../../picker';
 import type { Global } from '../../types';
 import { TAP_EPSILON } from '../shared';
 
@@ -25,11 +25,11 @@ type PickTarget = {
 class WalkInteraction {
     collision: Collision | null = null;
 
+    private _picker: Picker;
+
     private _global: Global | null = null;
 
     private _canvas: HTMLCanvasElement | null = null;
-
-    private _picker: Picker | null = null;
 
     private _lastPointerOffsetX = 0;
 
@@ -44,6 +44,10 @@ class WalkInteraction {
     private _targetPickRequest = 0;
 
     private _lastTap = { time: 0, x: 0, y: 0 };
+
+    constructor(picker: Picker) {
+        this._picker = picker;
+    }
 
     private _updateCursor = () => {
         const global = this._global;
@@ -94,10 +98,6 @@ class WalkInteraction {
         const collisionTarget = this._pickCollision(offsetX, offsetY);
         if (collisionTarget) {
             return collisionTarget;
-        }
-
-        if (!this._picker) {
-            this._picker = new Picker(global.app, global.camera);
         }
 
         const result = await this._picker.pickSurface(
@@ -222,11 +222,16 @@ class WalkInteraction {
         const { events, state } = global;
         const cameraMode = state.cameraMode;
         if (cameraMode === 'walk') return;
-        const request = ++this._targetPickRequest;
-        const target = await this._pickSceneTarget(event.offsetX, event.offsetY);
-        if (target && request === this._targetPickRequest && this._global?.state.cameraMode === cameraMode) {
-            events.fire('orbitTarget:set', target.position, target.normal);
-            events.fire('pick', target.position);
+
+        if (cameraMode === 'fly') {
+            this._flyToPickedPosition(event.offsetX, event.offsetY);
+        } else if (cameraMode === 'orbit') {
+            const request = ++this._targetPickRequest;
+            const target = await this._pickSceneTarget(event.offsetX, event.offsetY);
+            if (target && request === this._targetPickRequest && this._global?.state.cameraMode === cameraMode) {
+                events.fire('orbitTarget:set', target.position, target.normal);
+                events.fire('pick', target.position);
+            }
         }
     };
 
@@ -260,7 +265,7 @@ class WalkInteraction {
         canvas.addEventListener('pointermove', this._onPointerMove);
         canvas.addEventListener('pointerup', this._onPointerUp);
 
-        // double-click/tap fallback -> pick -> fire 'pick' event (skipped in walk mode)
+        // double-click/tap fallback -> fly target or orbit focus (skipped in walk mode)
         events.on('inputEvent', this._onInputEvent);
 
         // mobile tap (no movement) → walk/fly target or orbit focus
@@ -286,8 +291,6 @@ class WalkInteraction {
         }
         this._canvas = null;
         this._global = null;
-        this._picker?.release();
-        this._picker = null;
     }
 }
 

--- a/src/input/app/walk-interaction.ts
+++ b/src/input/app/walk-interaction.ts
@@ -7,11 +7,15 @@ import { TAP_EPSILON } from '../shared';
 
 const tmpV = new Vec3();
 
+type PickTarget = {
+    position: Vec3;
+    normal: Vec3;
+};
+
 /**
- * Click-to-walk (desktop), tap-to-walk (mobile), and double-click-to-pick
- * (orbit / fly) interaction. Uses a Picker against the collision mesh to
- * resolve the world-space target and fires `walkTo` / `pick` for the
- * camera manager to consume.
+ * Click-to-walk / click-to-fly / click-to-focus (desktop), tap equivalents
+ * on mobile, and double-click-to-pick fallback. Uses collision first and
+ * rendered-scene picking when collision is unavailable.
  */
 class WalkInteraction {
     collision: Collision | null = null;
@@ -30,6 +34,10 @@ class WalkInteraction {
 
     private _mouseClickDelta = 0;
 
+    private _suppressClick = false;
+
+    private _targetPickRequest = 0;
+
     private _lastTap = { time: 0, x: 0, y: 0 };
 
     private _updateCursor = () => {
@@ -44,7 +52,12 @@ class WalkInteraction {
         }
     };
 
-    private _pickCollision(offsetX: number, offsetY: number): { position: Vec3; normal: Vec3 } | null {
+    private _onCameraModeChanged = () => {
+        this._targetPickRequest++;
+        this._updateCursor();
+    };
+
+    private _pickCollision(offsetX: number, offsetY: number): PickTarget | null {
         if (!this.collision || !this._global) return null;
 
         const camera = this._global.camera;
@@ -68,16 +81,65 @@ class WalkInteraction {
         };
     }
 
+    private async _pickSceneTarget(offsetX: number, offsetY: number): Promise<PickTarget | null> {
+        const global = this._global;
+        const canvas = this._canvas;
+        if (!global || !canvas) return null;
+
+        const collisionTarget = this._pickCollision(offsetX, offsetY);
+        if (collisionTarget) {
+            return collisionTarget;
+        }
+
+        if (!this._picker) {
+            this._picker = new Picker(global.app, global.camera);
+        }
+
+        const result = await this._picker.pickSurface(
+            offsetX / canvas.clientWidth,
+            offsetY / canvas.clientHeight
+        );
+        if (result) {
+            return result;
+        }
+
+        return null;
+    }
+
+    private async _flyToPickedPosition(offsetX: number, offsetY: number) {
+        const global = this._global;
+        if (!global || global.state.cameraMode !== 'fly') return;
+
+        const request = ++this._targetPickRequest;
+        const target = await this._pickSceneTarget(offsetX, offsetY);
+        if (target && request === this._targetPickRequest && this._global?.state.cameraMode === 'fly') {
+            this._global.events.fire('flyTo', target.position, target.normal);
+        }
+    }
+
+    private async _focusPickedPosition(offsetX: number, offsetY: number) {
+        const global = this._global;
+        if (!global || global.state.cameraMode !== 'orbit') return;
+
+        const request = ++this._targetPickRequest;
+        const target = await this._pickSceneTarget(offsetX, offsetY);
+        if (target && request === this._targetPickRequest && this._global?.state.cameraMode === 'orbit') {
+            const { events } = this._global;
+            events.fire('orbitTarget:set', target.position, target.normal);
+            events.fire('pick', target.position);
+        }
+    }
+
     private _onPointerDown = (event: PointerEvent) => {
         const global = this._global;
         if (!global) return;
         const { events } = global;
 
-        // record offsets for click/tap-to-walk picking
+        // record offsets for click/tap target picking
         this._lastPointerOffsetX = event.offsetX;
         this._lastPointerOffsetY = event.offsetY;
 
-        // start desktop click-to-walk tracking
+        // start desktop click target tracking
         if (event.pointerType !== 'touch' && event.button === 0) {
             this._mouseClickTracking = true;
             this._mouseClickDelta = 0;
@@ -90,6 +152,7 @@ class WalkInteraction {
         if (delay < 300 &&
             Math.abs(event.clientX - this._lastTap.x) < 8 &&
             Math.abs(event.clientY - this._lastTap.y) < 8) {
+            this._suppressClick = true;
             events.fire('inputEvent', 'dblclick', event);
             this._lastTap.time = 0;
         } else {
@@ -110,6 +173,8 @@ class WalkInteraction {
             if (prev < TAP_EPSILON && this._mouseClickDelta >= TAP_EPSILON) {
                 if (state.cameraMode === 'walk' && !state.gamingControls) {
                     events.fire('walkCancel');
+                } else if (state.cameraMode === 'fly') {
+                    events.fire('flyCancel');
                 }
             }
         }
@@ -123,10 +188,20 @@ class WalkInteraction {
         if (this._mouseClickTracking && event.pointerType !== 'touch' && event.button === 0) {
             this._mouseClickTracking = false;
             this._updateCursor();
-            if (this._mouseClickDelta < TAP_EPSILON && state.cameraMode === 'walk' && !state.gamingControls) {
-                const result = this._pickCollision(this._lastPointerOffsetX, this._lastPointerOffsetY);
-                if (result) {
-                    events.fire('walkTo', result.position, result.normal);
+            if (this._suppressClick) {
+                this._suppressClick = false;
+                return;
+            }
+            if (this._mouseClickDelta < TAP_EPSILON) {
+                if (state.cameraMode === 'walk' && !state.gamingControls) {
+                    const result = this._pickCollision(this._lastPointerOffsetX, this._lastPointerOffsetY);
+                    if (result) {
+                        events.fire('walkTo', result.position, result.normal);
+                    }
+                } else if (state.cameraMode === 'fly') {
+                    this._flyToPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY);
+                } else if (state.cameraMode === 'orbit') {
+                    this._focusPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY);
                 }
             }
         }
@@ -138,17 +213,12 @@ class WalkInteraction {
         if (!global || !canvas) return;
         if (eventName !== 'dblclick') return;
         if (!(event instanceof MouseEvent)) return;
-        const { app, camera, events, state } = global;
+        const { events, state } = global;
         if (state.cameraMode === 'walk') return;
-        if (!this._picker) {
-            this._picker = new Picker(app, camera);
-        }
-        const result = await this._picker.pick(
-            event.offsetX / canvas.clientWidth,
-            event.offsetY / canvas.clientHeight
-        );
-        if (result) {
-            events.fire('pick', result);
+        const target = await this._pickSceneTarget(event.offsetX, event.offsetY);
+        if (target) {
+            events.fire('orbitTarget:set', target.position, target.normal);
+            events.fire('pick', target.position);
         }
     };
 
@@ -156,10 +226,20 @@ class WalkInteraction {
         const global = this._global;
         if (!global) return;
         const { state, events } = global;
-        if (state.cameraMode !== 'walk' || state.gamingControls) return;
-        const result = this._pickCollision(this._lastPointerOffsetX, this._lastPointerOffsetY);
-        if (result) {
-            events.fire('walkTo', result.position, result.normal);
+        if (this._suppressClick) {
+            this._suppressClick = false;
+            return;
+        }
+
+        if (state.cameraMode === 'walk' && !state.gamingControls) {
+            const result = this._pickCollision(this._lastPointerOffsetX, this._lastPointerOffsetY);
+            if (result) {
+                events.fire('walkTo', result.position, result.normal);
+            }
+        } else if (state.cameraMode === 'fly') {
+            this._flyToPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY);
+        } else if (state.cameraMode === 'orbit') {
+            this._focusPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY);
         }
     };
 
@@ -172,14 +252,14 @@ class WalkInteraction {
         canvas.addEventListener('pointermove', this._onPointerMove);
         canvas.addEventListener('pointerup', this._onPointerUp);
 
-        // double-click → pick → fire 'pick' event (skipped in walk mode)
+        // double-click fallback → pick → fire 'pick' event (skipped in walk mode)
         events.on('inputEvent', this._onInputEvent);
 
-        // mobile tap (no movement) → walkTo
+        // mobile tap (no movement) → walk/fly target or orbit focus
         events.on('mobileTap', this._onMobileTap);
 
         // refresh cursor on mode / gaming-controls change
-        events.on('cameraMode:changed', this._updateCursor);
+        events.on('cameraMode:changed', this._onCameraModeChanged);
         events.on('gamingControls:changed', this._updateCursor);
     }
 
@@ -193,11 +273,12 @@ class WalkInteraction {
             const { events } = this._global;
             events.off('inputEvent', this._onInputEvent);
             events.off('mobileTap', this._onMobileTap);
-            events.off('cameraMode:changed', this._updateCursor);
+            events.off('cameraMode:changed', this._onCameraModeChanged);
             events.off('gamingControls:changed', this._updateCursor);
         }
         this._canvas = null;
         this._global = null;
+        this._picker?.release();
         this._picker = null;
     }
 }

--- a/src/input/app/walk-interaction.ts
+++ b/src/input/app/walk-interaction.ts
@@ -54,7 +54,12 @@ class WalkInteraction {
         const canvas = this._canvas;
         if (!global || !canvas) return;
         const { state } = global;
-        if (state.cameraMode === 'walk' && !state.gamingControls && state.inputMode === 'desktop') {
+        const canClickTarget = state.inputMode === 'desktop' && (
+            (state.cameraMode === 'walk' && !state.gamingControls) ||
+            canTargetFly(global) ||
+            state.cameraMode === 'orbit'
+        );
+        if (canClickTarget) {
             canvas.style.cursor = this._mouseClickTracking ? 'default' : 'pointer';
         } else {
             canvas.style.cursor = '';
@@ -179,7 +184,7 @@ class WalkInteraction {
             if (prev < TAP_EPSILON && this._mouseClickDelta >= TAP_EPSILON) {
                 if (state.cameraMode === 'walk' && !state.gamingControls) {
                     events.fire('walkCancel');
-                } else if (state.cameraMode === 'fly') {
+                } else if (canTargetFly(global)) {
                     events.fire('flyCancel');
                 }
             }
@@ -273,6 +278,7 @@ class WalkInteraction {
 
         // refresh cursor on mode / gaming-controls change
         events.on('cameraMode:changed', this._onCameraModeChanged);
+        events.on('inputMode:changed', this._updateCursor);
         events.on('gamingControls:changed', this._updateCursor);
     }
 
@@ -287,6 +293,7 @@ class WalkInteraction {
             events.off('inputEvent', this._onInputEvent);
             events.off('mobileTap', this._onMobileTap);
             events.off('cameraMode:changed', this._onCameraModeChanged);
+            events.off('inputMode:changed', this._updateCursor);
             events.off('gamingControls:changed', this._updateCursor);
         }
         this._canvas = null;

--- a/src/input/app/walk-interaction.ts
+++ b/src/input/app/walk-interaction.ts
@@ -220,9 +220,11 @@ class WalkInteraction {
         if (eventName !== 'dblclick') return;
         if (!(event instanceof MouseEvent)) return;
         const { events, state } = global;
-        if (state.cameraMode === 'walk') return;
+        const cameraMode = state.cameraMode;
+        if (cameraMode === 'walk') return;
+        const request = ++this._targetPickRequest;
         const target = await this._pickSceneTarget(event.offsetX, event.offsetY);
-        if (target) {
+        if (target && request === this._targetPickRequest && this._global?.state.cameraMode === cameraMode) {
             events.fire('orbitTarget:set', target.position, target.normal);
             events.fire('pick', target.position);
         }

--- a/src/input/app/walk-interaction.ts
+++ b/src/input/app/walk-interaction.ts
@@ -7,6 +7,11 @@ import { TAP_EPSILON } from '../shared';
 
 const tmpV = new Vec3();
 
+const canTargetFly = (global: Global) => (
+    global.state.cameraMode === 'fly' &&
+    !(global.state.inputMode === 'desktop' && global.state.gamingControls)
+);
+
 type PickTarget = {
     position: Vec3;
     normal: Vec3;
@@ -108,11 +113,11 @@ class WalkInteraction {
 
     private async _flyToPickedPosition(offsetX: number, offsetY: number) {
         const global = this._global;
-        if (!global || global.state.cameraMode !== 'fly') return;
+        if (!global || !canTargetFly(global)) return;
 
         const request = ++this._targetPickRequest;
         const target = await this._pickSceneTarget(offsetX, offsetY);
-        if (target && request === this._targetPickRequest && this._global?.state.cameraMode === 'fly') {
+        if (target && request === this._targetPickRequest && this._global && canTargetFly(this._global)) {
             this._global.events.fire('flyTo', target.position, target.normal);
         }
     }

--- a/src/input/app/walk-interaction.ts
+++ b/src/input/app/walk-interaction.ts
@@ -151,7 +151,8 @@ class WalkInteraction {
             this._updateCursor();
         }
 
-        // manual double-tap detection (iOS doesn't send dblclick)
+        // Manual double-click/tap detection for platforms that do not emit
+        // reliable native dblclick events on the canvas.
         const now = Date.now();
         const delay = Math.max(0, now - this._lastTap.time);
         if (delay < 300 &&
@@ -257,7 +258,7 @@ class WalkInteraction {
         canvas.addEventListener('pointermove', this._onPointerMove);
         canvas.addEventListener('pointerup', this._onPointerUp);
 
-        // double-click fallback → pick → fire 'pick' event (skipped in walk mode)
+        // double-click/tap fallback -> pick -> fire 'pick' event (skipped in walk mode)
         events.on('inputEvent', this._onInputEvent);
 
         // mobile tap (no movement) → walk/fly target or orbit focus

--- a/src/input/devices/gamepad.ts
+++ b/src/input/devices/gamepad.ts
@@ -16,17 +16,26 @@ class GamepadDevice implements InputDevice {
 
     private _source = new GamepadSource();
 
-    attach(_canvas: HTMLCanvasElement, _global: Global): void {
+    private _global: Global | null = null;
+
+    attach(_canvas: HTMLCanvasElement, global: Global): void {
+        this._global = global;
         // GamepadSource polls navigator.getGamepads() — no DOM attach needed.
     }
 
-    detach(): void {}
+    detach(): void {
+        this._global = null;
+    }
 
     update(ctx: UpdateContext, frame: CameraInputFrame): void {
-        const { dt, cameraComponent, isFirstPerson } = ctx;
+        const { dt, cameraComponent, isFly, isFirstPerson } = ctx;
         const { leftStick, rightStick } = this._source.read();
         const orbitFactor = isFirstPerson ? cameraComponent.fov / 120 : 1;
         const { deltas } = frame;
+
+        if (isFly && (leftStick[0] !== 0 || leftStick[1] !== 0 || rightStick[0] !== 0 || rightStick[1] !== 0)) {
+            this._global?.events.fire('flyCancel');
+        }
 
         const v = tmpV.set(0, 0, 0);
         stickMove.set(leftStick[0], 0, -leftStick[1]);

--- a/src/input/devices/keyboard-mouse.ts
+++ b/src/input/devices/keyboard-mouse.ts
@@ -112,6 +112,7 @@ class KeyboardMouseDevice implements InputDevice {
         }
 
         const { isFly, isWalk, isFirstPerson, gamingControls, dt, distance, cameraComponent, mode, touchCount } = ctx;
+        const pan = this._buttons[2] || +(button[2] === -1) || +(touchCount > 1);
 
         // auto-move cancellation and requestFirstPerson events (driven by keyboard axes)
         if (isWalk && (this._axis.x !== 0 || this._axis.z !== 0)) {
@@ -123,15 +124,13 @@ class KeyboardMouseDevice implements InputDevice {
         if (isFly && wheel[0] !== 0) {
             events.fire('flyCancel');
         }
-        if (isFly && gamingControls && (mouse[0] !== 0 || mouse[1] !== 0)) {
+        if (isFly && (gamingControls || pan) && (mouse[0] !== 0 || mouse[1] !== 0)) {
             events.fire('flyCancel');
         }
         if (!isFirstPerson && this._axis.length() > 0) {
             events.fire('inputEvent', 'requestFirstPerson');
         }
 
-        // pan flag: RMB held, RMB just released this frame, or 2+ touches active
-        const pan = this._buttons[2] || +(button[2] === -1) || +(touchCount > 1);
         const orbitFactor = isFirstPerson ? cameraComponent.fov / 120 : 1;
 
         const { deltas } = frame;

--- a/src/input/devices/keyboard-mouse.ts
+++ b/src/input/devices/keyboard-mouse.ts
@@ -102,11 +102,14 @@ class KeyboardMouseDevice implements InputDevice {
             this._buttons[i] += button[i];
         }
 
-        const { isWalk, isFirstPerson, dt, distance, cameraComponent, mode, touchCount } = ctx;
+        const { isFly, isWalk, isFirstPerson, dt, distance, cameraComponent, mode, touchCount } = ctx;
 
-        // walk-cancel and requestFirstPerson events (driven by WASD axis)
+        // auto-move cancellation and requestFirstPerson events (driven by keyboard axes)
         if (isWalk && (this._axis.x !== 0 || this._axis.z !== 0)) {
             events.fire('walkCancel');
+        }
+        if (isFly && (this._axis.x !== 0 || this._axis.y !== 0 || this._axis.z !== 0)) {
+            events.fire('flyCancel');
         }
         if (!isFirstPerson && this._axis.length() > 0) {
             events.fire('inputEvent', 'requestFirstPerson');

--- a/src/input/devices/keyboard-mouse.ts
+++ b/src/input/devices/keyboard-mouse.ts
@@ -120,6 +120,9 @@ class KeyboardMouseDevice implements InputDevice {
         if (isFly && (this._axis.x !== 0 || this._axis.y !== 0 || this._axis.z !== 0)) {
             events.fire('flyCancel');
         }
+        if (isFly && wheel[0] !== 0) {
+            events.fire('flyCancel');
+        }
         if (!isFirstPerson && this._axis.length() > 0) {
             events.fire('inputEvent', 'requestFirstPerson');
         }

--- a/src/input/devices/keyboard-mouse.ts
+++ b/src/input/devices/keyboard-mouse.ts
@@ -1,5 +1,6 @@
 import { KeyboardMouseSource, Vec3 } from 'playcanvas';
 
+import { damp } from '../../core/math';
 import type { Global } from '../../types';
 import {
     DISPLACEMENT_SCALE,
@@ -9,7 +10,9 @@ import {
 import type { CameraInputFrame, InputDevice, UpdateContext } from '../shared';
 
 const tmpV1 = new Vec3();
+const tmpV2 = new Vec3();
 const keyMove = new Vec3();
+const flyKeyVelocity = new Vec3();
 const panMove = new Vec3();
 const mouseRotate = new Vec3();
 const wheelMove = new Vec3();
@@ -45,6 +48,10 @@ class KeyboardMouseDevice implements InputDevice {
 
     mouseRotateSensitivity: number = 0.5;
 
+    flyMoveAccelerationDamping: number = 0.992;
+
+    flyMoveDecelerationDamping: number = 0.993;
+
     private _source: KeyboardMouseSource = new KeyboardMouseSource();
 
     private _global: Global | null = null;
@@ -60,6 +67,8 @@ class KeyboardMouseDevice implements InputDevice {
     private _ctrl = 0;
 
     private _jump = 0;
+
+    private _flyKeyVelocity = new Vec3();
 
     /**
      * Get the underlying source so other code (PointerLockManager) can
@@ -133,7 +142,21 @@ class KeyboardMouseDevice implements InputDevice {
         const shiftMul = isWalk ? 2 : 4;
         const ctrlMul = isWalk ? 0.5 : 0.25;
         const speed = this.moveSpeed * (this._shift ? shiftMul : this._ctrl ? ctrlMul : 1);
-        v.add(keyMove.mulScalar((isFirstPerson ? 1 : 0) * speed * dt));
+        keyMove.mulScalar(speed);
+        if (isFly) {
+            flyKeyVelocity.copy(keyMove);
+            const damping = flyKeyVelocity.lengthSq() > this._flyKeyVelocity.lengthSq() ?
+                this.flyMoveAccelerationDamping :
+                this.flyMoveDecelerationDamping;
+            this._flyKeyVelocity.lerp(this._flyKeyVelocity, flyKeyVelocity, damp(damping, dt));
+            if (flyKeyVelocity.lengthSq() === 0 && this._flyKeyVelocity.lengthSq() < 1e-4) {
+                this._flyKeyVelocity.set(0, 0, 0);
+            }
+            keyMove.copy(this._flyKeyVelocity);
+        } else {
+            this._flyKeyVelocity.set(0, 0, 0);
+        }
+        v.add(tmpV2.copy(keyMove).mulScalar((isFirstPerson ? 1 : 0) * dt));
         if (isWalk) {
             // Pass jump signal as raw Y; WalkController uses move[1] > 0 as
             // a boolean trigger.

--- a/src/input/devices/keyboard-mouse.ts
+++ b/src/input/devices/keyboard-mouse.ts
@@ -123,6 +123,9 @@ class KeyboardMouseDevice implements InputDevice {
         if (isFly && wheel[0] !== 0) {
             events.fire('flyCancel');
         }
+        if (isFly && (mouse[0] !== 0 || mouse[1] !== 0)) {
+            events.fire('flyCancel');
+        }
         if (!isFirstPerson && this._axis.length() > 0) {
             events.fire('inputEvent', 'requestFirstPerson');
         }

--- a/src/input/devices/keyboard-mouse.ts
+++ b/src/input/devices/keyboard-mouse.ts
@@ -111,7 +111,7 @@ class KeyboardMouseDevice implements InputDevice {
             this._buttons[i] += button[i];
         }
 
-        const { isFly, isWalk, isFirstPerson, dt, distance, cameraComponent, mode, touchCount } = ctx;
+        const { isFly, isWalk, isFirstPerson, gamingControls, dt, distance, cameraComponent, mode, touchCount } = ctx;
 
         // auto-move cancellation and requestFirstPerson events (driven by keyboard axes)
         if (isWalk && (this._axis.x !== 0 || this._axis.z !== 0)) {
@@ -123,7 +123,7 @@ class KeyboardMouseDevice implements InputDevice {
         if (isFly && wheel[0] !== 0) {
             events.fire('flyCancel');
         }
-        if (isFly && (mouse[0] !== 0 || mouse[1] !== 0)) {
+        if (isFly && gamingControls && (mouse[0] !== 0 || mouse[1] !== 0)) {
             events.fire('flyCancel');
         }
         if (!isFirstPerson && this._axis.length() > 0) {

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -118,7 +118,7 @@ class TouchDevice implements InputDevice {
                         this._global!.events.fire('mobileTap');
                     } else if (isWalk) {
                         this._tapJump = true;
-                    } else if (isFly) {
+                    } else if (isFly && !gamingControls) {
                         // Walk-interaction listens for this and fires flyTo
                         // after picking.
                         this._global!.events.fire('mobileTap');

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -100,7 +100,7 @@ class TouchDevice implements InputDevice {
 
             if (this._tapTouches > 0) {
                 const prevDelta = this._tapDelta;
-                this._tapDelta += Math.abs(touch[0]) + Math.abs(touch[1]);
+                this._tapDelta += Math.abs(touch[0]) + Math.abs(touch[1]) + Math.abs(pinch[0]);
                 if (prevDelta < TAP_EPSILON && this._tapDelta >= TAP_EPSILON) {
                     if (isWalk && !gamingControls) {
                         this._global!.events.fire('walkCancel');

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -80,13 +80,17 @@ class TouchDevice implements InputDevice {
 
     update(ctx: UpdateContext, frame: CameraInputFrame): void {
         const { touch, pinch, count } = this._source.read();
-        const { isWalk, isFirstPerson, isOrbit, gamingControls, dt, distance, cameraComponent } = ctx;
+        const { isFly, isWalk, isFirstPerson, isOrbit, gamingControls, dt, distance, cameraComponent } = ctx;
 
         // running touch count
         this._touchCount += count[0];
 
-        // tap detection (walk mode only)
-        if (isWalk) {
+        if (isFly && gamingControls && (this._joystick[0] !== 0 || this._joystick[1] !== 0)) {
+            this._global!.events.fire('flyCancel');
+        }
+
+        // tap detection for click/tap target and focus modes
+        if (isWalk || isFly || isOrbit) {
             const prevTaps = this._tapTouches;
             this._tapTouches = Math.max(0, this._tapTouches + count[0]);
 
@@ -98,20 +102,30 @@ class TouchDevice implements InputDevice {
                 const prevDelta = this._tapDelta;
                 this._tapDelta += Math.abs(touch[0]) + Math.abs(touch[1]);
                 if (prevDelta < TAP_EPSILON && this._tapDelta >= TAP_EPSILON) {
-                    if (!gamingControls) {
+                    if (isWalk && !gamingControls) {
                         this._global!.events.fire('walkCancel');
+                    } else if (isFly) {
+                        this._global!.events.fire('flyCancel');
                     }
                 }
             }
 
             if (prevTaps > 0 && this._tapTouches === 0) {
                 if (this._tapDelta < TAP_EPSILON) {
-                    if (!gamingControls) {
+                    if (isWalk && !gamingControls) {
                         // Walk-interaction listens for this and fires walkTo
                         // after picking.
                         this._global!.events.fire('mobileTap');
-                    } else {
+                    } else if (isWalk) {
                         this._tapJump = true;
+                    } else if (isFly) {
+                        // Walk-interaction listens for this and fires flyTo
+                        // after picking.
+                        this._global!.events.fire('mobileTap');
+                    } else if (isOrbit) {
+                        // Walk-interaction listens for this and sets orbit focus
+                        // after picking.
+                        this._global!.events.fire('mobileTap');
                     }
                 }
             }

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -47,8 +47,10 @@ class TouchDevice implements InputDevice {
     /** Smoothed strafe/vertical velocity from two-finger pan, -1..1 each. */
     private _panVelocity: [number, number] = [0, 0];
 
-    /** Tap-detection state — touch count and accumulated finger movement. */
+    /** Tap-detection state — touch count, max touches, and accumulated movement. */
     private _tapTouches = 0;
+
+    private _tapMaxTouches = 0;
 
     private _tapDelta = 0;
 
@@ -97,6 +99,9 @@ class TouchDevice implements InputDevice {
             if (prevTaps === 0 && this._tapTouches > 0) {
                 this._tapDelta = 0;
             }
+            if (this._tapTouches > 0) {
+                this._tapMaxTouches = Math.max(this._tapMaxTouches, this._tapTouches);
+            }
 
             if (this._tapTouches > 0) {
                 const prevDelta = this._tapDelta;
@@ -111,7 +116,7 @@ class TouchDevice implements InputDevice {
             }
 
             if (prevTaps > 0 && this._tapTouches === 0) {
-                if (this._tapDelta < TAP_EPSILON) {
+                if (this._tapDelta < TAP_EPSILON && this._tapMaxTouches === 1) {
                     if (isWalk && !gamingControls) {
                         // Walk-interaction listens for this and fires walkTo
                         // after picking.
@@ -128,9 +133,11 @@ class TouchDevice implements InputDevice {
                         this._global!.events.fire('mobileTap');
                     }
                 }
+                this._tapMaxTouches = 0;
             }
         } else {
             this._tapTouches = 0;
+            this._tapMaxTouches = 0;
         }
 
         // smoothed velocities for fly/walk first-person motion (non-gaming)

--- a/src/input/devices/trackpad.ts
+++ b/src/input/devices/trackpad.ts
@@ -75,6 +75,9 @@ class TrackpadDevice implements InputDevice {
             }
         } else {
             // fly / walk: always rotate (shift is a speed modifier, not a gesture)
+            if (mode === 'fly') {
+                this._global!.events.fire('flyCancel');
+            }
             this._orbit[0] += deltaX;
             this._orbit[1] += deltaY;
         }

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,5 +1,5 @@
 /**
- * Double-click world picking for splat scenes.
+ * World picking for splat scenes.
  *
  * - **Compute renderer (WebGPU tiled-compute)**: uses engine `Picker` with depth enabled — expected
  *   depth is already provided by the tile-composite path.
@@ -476,13 +476,6 @@ class Picker {
             cacheReady = false;
         };
 
-        const pickPixel = (x: number, y: number, width: number, height: number) => {
-            const sx = Math.min(width - 1, Math.max(0, x));
-            const sy = Math.min(height - 1, Math.max(0, y));
-
-            return this.pick((sx + 0.5) / width, (sy + 0.5) / height);
-        };
-
         const readRasterBlock = async (
             blockX: number,
             blockY: number,
@@ -585,13 +578,15 @@ class Picker {
                 }
             }
 
+            const pickCamera = getCacheCameraSnapshot();
+
             if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
-                const pickCamera = getCacheCameraSnapshot();
-                const position = await enginePicker!.getWorldPointAsync(screenX, screenY);
+                const normalizedDepth = await enginePicker!.getPointDepthAsync(screenX, screenY);
+                const position = normalizedDepth !== null ?
+                    getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth) :
+                    null;
                 return position ? { position, camera: pickCamera } : null;
             }
-
-            const pickCamera = getCacheCameraSnapshot();
 
             try {
                 if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
@@ -659,9 +654,15 @@ class Picker {
                     return Promise.resolve(null);
                 }
 
-                return rasterBlock ?
-                    Promise.resolve(rasterBlock(px, py)) :
-                    pickPixel(px, py, width, height);
+                if (rasterBlock) {
+                    return Promise.resolve(rasterBlock(px, py));
+                }
+
+                return enginePicker!.getPointDepthAsync(px, py).then((normalizedDepth) => {
+                    return normalizedDepth !== null ?
+                        getWorldPoint(picked.camera, px, py, width, height, normalizedDepth) :
+                        null;
+                });
             };
 
             const sampleRings = await Promise.all(NORMAL_SAMPLE_RADII.map((radius) => {

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -371,6 +371,7 @@ class Picker {
         let accumTarget: RenderTarget;
         let accumPass: RenderPassPicker;
         let chunksPatched = false;
+        let pickQueue = Promise.resolve();
         const cacheCamera: PickCameraSnapshot = {
             position: new Vec3(),
             viewMatrix: new Mat4(),
@@ -560,12 +561,19 @@ class Picker {
             return position ? { position, camera: pickCamera, isComputeRenderer } : null;
         };
 
-        this.pick = async (x: number, y: number) => {
+        const serializePick = <T>(operation: () => Promise<T>): Promise<T> => {
+            // The render targets are shared by all picks on this instance.
+            const result = pickQueue.then(operation, operation);
+            pickQueue = result.then((): void => undefined, (): void => undefined);
+            return result;
+        };
+
+        const pick = async (x: number, y: number) => {
             const result = await pickPosition(x, y);
             return result?.position ?? null;
         };
 
-        this.pickSurface = async (x: number, y: number) => {
+        const pickSurface = async (x: number, y: number) => {
             const width = Math.floor(graphicsDevice.width);
             const height = Math.floor(graphicsDevice.height);
 
@@ -682,6 +690,10 @@ class Picker {
                 normal
             };
         };
+
+        this.pick = (x: number, y: number) => serializePick(() => pick(x, y));
+
+        this.pickSurface = (x: number, y: number) => serializePick(() => pickSurface(x, y));
 
         this.release = () => {
             if (chunksPatched) {

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -223,15 +223,23 @@ const matrixEquals = (a: Float32Array<ArrayBufferLike>, b: Float32Array<ArrayBuf
     return true;
 };
 
-const copyMatrix = (src: Float32Array<ArrayBufferLike>, dst: Float32Array<ArrayBuffer>) => {
-    for (let i = 0; i < 16; i++) {
-        dst[i] = src[i];
-    }
-};
-
 type PickSurface = {
     position: Vec3;
     normal: Vec3;
+};
+
+type PickCameraSnapshot = {
+    position: Vec3;
+    viewMatrix: Mat4;
+    projectionMatrix: Mat4;
+    nearClip: number;
+    farClip: number;
+    projection: number;
+};
+
+type PickPosition = {
+    position: Vec3;
+    camera: PickCameraSnapshot;
 };
 
 // Shared buffer for half-to-float conversion
@@ -320,19 +328,17 @@ const unregisterPickerShaderPatches = (app: AppBase) => {
     pickerShaderPatchState.delete(device);
 };
 
-const getWorldPoint = (camera: Entity, x: number, y: number, width: number, height: number, normalizedDepth: number) => {
+const getWorldPoint = (camera: PickCameraSnapshot, x: number, y: number, width: number, height: number, normalizedDepth: number) => {
     if (!Number.isFinite(normalizedDepth) || normalizedDepth < 0 || normalizedDepth > 1) {
         return null;
     }
 
-    const cam = camera.camera;
-    const far = cam.farClip;
-    const near = cam.nearClip;
-    const ndcDepth = cam.projection === PROJECTION_ORTHOGRAPHIC ?
+    const { farClip: far, nearClip: near } = camera;
+    const ndcDepth = camera.projection === PROJECTION_ORTHOGRAPHIC ?
         normalizedDepth :
         far * normalizedDepth / (normalizedDepth * (far - near) + near);
 
-    viewProjMat.mul2(cam.projectionMatrix, cam.viewMatrix).invert();
+    viewProjMat.mul2(camera.projectionMatrix, camera.viewMatrix).invert();
     vec4.set(x / width * 2 - 1, (1 - y / height) * 2 - 1, ndcDepth * 2 - 1, 1);
     viewProjMat.transformVec4(vec4, vec4);
     if (!Number.isFinite(vec4.w) || Math.abs(vec4.w) < 1e-8) {
@@ -347,8 +353,8 @@ const getWorldPoint = (camera: Entity, x: number, y: number, width: number, heig
     return new Vec3(vec4.x, vec4.y, vec4.z);
 };
 
-const setCameraFacingNormal = (camera: Entity, position: Vec3, normal: Vec3) => {
-    normal.sub2(camera.getPosition(), position);
+const setCameraFacingNormal = (cameraPosition: Vec3, position: Vec3, normal: Vec3) => {
+    normal.sub2(cameraPosition, position);
     const len = normal.length();
     if (len > 1e-6) {
         normal.mulScalar(1 / len);
@@ -378,8 +384,14 @@ class Picker {
         let cacheWidth = 0;
         let cacheHeight = 0;
         let cacheRenderer = -1;
-        const cacheView = new Float32Array(16);
-        const cacheProj = new Float32Array(16);
+        const cacheCamera: PickCameraSnapshot = {
+            position: new Vec3(),
+            viewMatrix: new Mat4(),
+            projectionMatrix: new Mat4(),
+            nearClip: 0,
+            farClip: 0,
+            projection: 0
+        };
 
         const initRasterAccum = (width: number, height: number) => {
             accumBuffer = new Texture(graphicsDevice, {
@@ -428,8 +440,11 @@ class Picker {
                 cacheWidth === width &&
                 cacheHeight === height &&
                 cacheRenderer === app.scene.gsplat.currentRenderer &&
-                matrixEquals(cam.viewMatrix.data, cacheView) &&
-                matrixEquals(cam.projectionMatrix.data, cacheProj);
+                cam.nearClip === cacheCamera.nearClip &&
+                cam.farClip === cacheCamera.farClip &&
+                cam.projection === cacheCamera.projection &&
+                matrixEquals(cam.viewMatrix.data, cacheCamera.viewMatrix.data) &&
+                matrixEquals(cam.projectionMatrix.data, cacheCamera.projectionMatrix.data);
         };
 
         const updateCache = (width: number, height: number) => {
@@ -438,8 +453,23 @@ class Picker {
             cacheWidth = width;
             cacheHeight = height;
             cacheRenderer = app.scene.gsplat.currentRenderer;
-            copyMatrix(cam.viewMatrix.data, cacheView);
-            copyMatrix(cam.projectionMatrix.data, cacheProj);
+            cacheCamera.position.copy(camera.getPosition());
+            cacheCamera.viewMatrix.copy(cam.viewMatrix);
+            cacheCamera.projectionMatrix.copy(cam.projectionMatrix);
+            cacheCamera.nearClip = cam.nearClip;
+            cacheCamera.farClip = cam.farClip;
+            cacheCamera.projection = cam.projection;
+        };
+
+        const getCacheCameraSnapshot = (): PickCameraSnapshot => {
+            return {
+                position: cacheCamera.position.clone(),
+                viewMatrix: cacheCamera.viewMatrix.clone(),
+                projectionMatrix: cacheCamera.projectionMatrix.clone(),
+                nearClip: cacheCamera.nearClip,
+                farClip: cacheCamera.farClip,
+                projection: cacheCamera.projection
+            };
         };
 
         const invalidateCache = () => {
@@ -459,7 +489,8 @@ class Picker {
             blockWidth: number,
             blockHeight: number,
             viewportWidth: number,
-            viewportHeight: number
+            viewportHeight: number,
+            pickCamera: PickCameraSnapshot
         ) => {
             const texY = graphicsDevice.isWebGL2 ? accumTarget.height - blockY - blockHeight : blockY;
 
@@ -487,7 +518,7 @@ class Picker {
                     }
 
                     const normalizedDepth = r / alpha;
-                    return getWorldPoint(camera, x, y, viewportWidth, viewportHeight, normalizedDepth);
+                    return getWorldPoint(pickCamera, x, y, viewportWidth, viewportHeight, normalizedDepth);
                 };
             } catch (e) {
                 invalidateCache();
@@ -495,7 +526,7 @@ class Picker {
             }
         };
 
-        this.pick = async (x: number, y: number) => {
+        const pickPosition = async (x: number, y: number): Promise<PickPosition | null> => {
             const width = Math.floor(graphicsDevice.width);
             const height = Math.floor(graphicsDevice.height);
 
@@ -555,8 +586,12 @@ class Picker {
             }
 
             if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
-                return await enginePicker!.getWorldPointAsync(screenX, screenY);
+                const pickCamera = getCacheCameraSnapshot();
+                const position = await enginePicker!.getWorldPointAsync(screenX, screenY);
+                return position ? { position, camera: pickCamera } : null;
             }
+
+            const pickCamera = getCacheCameraSnapshot();
 
             try {
                 if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
@@ -575,11 +610,17 @@ class Picker {
                 }
 
                 const normalizedDepth = r / alpha;
-                return getWorldPoint(camera, screenX, screenY, width, height, normalizedDepth);
+                const position = getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth);
+                return position ? { position, camera: pickCamera } : null;
             } catch (e) {
                 invalidateCache();
                 throw e;
             }
+        };
+
+        this.pick = async (x: number, y: number) => {
+            const result = await pickPosition(x, y);
+            return result?.position ?? null;
         };
 
         this.pickSurface = async (x: number, y: number) => {
@@ -592,10 +633,11 @@ class Picker {
 
             const screenX = Math.min(width - 1, Math.max(0, Math.floor(x * width)));
             const screenY = Math.min(height - 1, Math.max(0, Math.floor(y * height)));
-            const position = await this.pick((screenX + 0.5) / width, (screenY + 0.5) / height);
-            if (!position) {
+            const picked = await pickPosition((screenX + 0.5) / width, (screenY + 0.5) / height);
+            if (!picked) {
                 return null;
             }
+            const { position } = picked;
 
             const maxRadius = NORMAL_SAMPLE_RADII[NORMAL_SAMPLE_RADII.length - 1];
             const blockX = Math.max(0, screenX - maxRadius);
@@ -608,7 +650,8 @@ class Picker {
                 blockWidth,
                 blockHeight,
                 width,
-                height
+                height,
+                picked.camera
             );
 
             const samplePixel = (px: number, py: number) => {
@@ -630,7 +673,7 @@ class Picker {
                 }));
             }));
 
-            const toCamera = setCameraFacingNormal(camera, position, new Vec3());
+            const toCamera = setCameraFacingNormal(picked.camera.position, position, new Vec3());
             const candidates: Vec3[] = [];
             const va = new Vec3();
             const vb = new Vec3();

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -199,6 +199,40 @@ const pickerShaderPatchState = new WeakMap<object, PickerShaderPatchState>();
 const vec4 = new Vec4();
 const viewProjMat = new Mat4();
 const clearColor = new Color(0, 0, 0, 1);
+const MATRIX_EPSILON = 1e-6;
+const NORMAL_EPSILON = 1e-12;
+const NORMAL_OUTLIER_MIN_DOT = 0.35;
+const NORMAL_SAMPLE_RADII = [1, 2, 4, 8];
+const NORMAL_SAMPLE_DIRECTIONS = [
+    [1, 0],
+    [1, 1],
+    [0, 1],
+    [-1, 1],
+    [-1, 0],
+    [-1, -1],
+    [0, -1],
+    [1, -1]
+] as const;
+
+const matrixEquals = (a: Float32Array<ArrayBufferLike>, b: Float32Array<ArrayBufferLike>) => {
+    for (let i = 0; i < 16; i++) {
+        if (Math.abs(a[i] - b[i]) > MATRIX_EPSILON) {
+            return false;
+        }
+    }
+    return true;
+};
+
+const copyMatrix = (src: Float32Array<ArrayBufferLike>, dst: Float32Array<ArrayBuffer>) => {
+    for (let i = 0; i < 16; i++) {
+        dst[i] = src[i];
+    }
+};
+
+type PickSurface = {
+    position: Vec3;
+    normal: Vec3;
+};
 
 // Shared buffer for half-to-float conversion
 const float32 = new Float32Array(1);
@@ -313,8 +347,22 @@ const getWorldPoint = (camera: Entity, x: number, y: number, width: number, heig
     return new Vec3(vec4.x, vec4.y, vec4.z);
 };
 
+const setCameraFacingNormal = (camera: Entity, position: Vec3, normal: Vec3) => {
+    normal.sub2(camera.getPosition(), position);
+    const len = normal.length();
+    if (len > 1e-6) {
+        normal.mulScalar(1 / len);
+    } else {
+        normal.set(0, 1, 0);
+    }
+
+    return normal;
+};
+
 class Picker {
     pick: (x: number, y: number) => Promise<Vec3 | null>;
+
+    pickSurface: (x: number, y: number) => Promise<PickSurface | null>;
 
     release: () => void;
 
@@ -326,6 +374,12 @@ class Picker {
         let accumTarget: RenderTarget;
         let accumPass: RenderPassPicker;
         let chunksPatched = false;
+        let cacheReady = false;
+        let cacheWidth = 0;
+        let cacheHeight = 0;
+        let cacheRenderer = -1;
+        const cacheView = new Float32Array(16);
+        const cacheProj = new Float32Array(16);
 
         const initRasterAccum = (width: number, height: number) => {
             accumBuffer = new Texture(graphicsDevice, {
@@ -368,6 +422,79 @@ class Picker {
             }) as Promise<T>;
         };
 
+        const isCacheValid = (width: number, height: number) => {
+            const cam = camera.camera;
+            return cacheReady &&
+                cacheWidth === width &&
+                cacheHeight === height &&
+                cacheRenderer === app.scene.gsplat.currentRenderer &&
+                matrixEquals(cam.viewMatrix.data, cacheView) &&
+                matrixEquals(cam.projectionMatrix.data, cacheProj);
+        };
+
+        const updateCache = (width: number, height: number) => {
+            const cam = camera.camera;
+            cacheReady = true;
+            cacheWidth = width;
+            cacheHeight = height;
+            cacheRenderer = app.scene.gsplat.currentRenderer;
+            copyMatrix(cam.viewMatrix.data, cacheView);
+            copyMatrix(cam.projectionMatrix.data, cacheProj);
+        };
+
+        const invalidateCache = () => {
+            cacheReady = false;
+        };
+
+        const pickPixel = (x: number, y: number, width: number, height: number) => {
+            const sx = Math.min(width - 1, Math.max(0, x));
+            const sy = Math.min(height - 1, Math.max(0, y));
+
+            return this.pick((sx + 0.5) / width, (sy + 0.5) / height);
+        };
+
+        const readRasterBlock = async (
+            blockX: number,
+            blockY: number,
+            blockWidth: number,
+            blockHeight: number,
+            viewportWidth: number,
+            viewportHeight: number
+        ) => {
+            const texY = graphicsDevice.isWebGL2 ? accumTarget.height - blockY - blockHeight : blockY;
+
+            try {
+                const pixels = await accumBuffer.read(blockX, texY, blockWidth, blockHeight, {
+                    renderTarget: accumTarget,
+                    immediate: true
+                }) as Uint16Array;
+
+                return (x: number, y: number) => {
+                    const localX = x - blockX;
+                    const localY = y - blockY;
+                    if (localX < 0 || localX >= blockWidth || localY < 0 || localY >= blockHeight) {
+                        return null;
+                    }
+
+                    const row = graphicsDevice.isWebGL2 ? blockHeight - localY - 1 : localY;
+                    const index = (row * blockWidth + localX) * 4;
+                    const r = half2Float(pixels[index]);
+                    const transmittance = half2Float(pixels[index + 3]);
+                    const alpha = 1 - transmittance;
+
+                    if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
+                        return null;
+                    }
+
+                    const normalizedDepth = r / alpha;
+                    return getWorldPoint(camera, x, y, viewportWidth, viewportHeight, normalizedDepth);
+                };
+            } catch (e) {
+                invalidateCache();
+                throw e;
+            }
+        };
+
         this.pick = async (x: number, y: number) => {
             const width = Math.floor(graphicsDevice.width);
             const height = Math.floor(graphicsDevice.height);
@@ -384,40 +511,58 @@ class Picker {
                 return null;
             }
 
-            // enable gsplat IDs only for the duration of the pick so we don't pay the
-            // memory/perf cost between picks (picker instances are typically long-lived).
-            const prevEnableIds = app.scene.gsplat.enableIds;
-            app.scene.gsplat.enableIds = true;
+            if (!isCacheValid(width, height)) {
+                // Enable gsplat IDs only while rendering the pick target so we
+                // don't pay the memory/perf cost between pick passes.
+                const prevEnableIds = app.scene.gsplat.enableIds;
+                app.scene.gsplat.enableIds = true;
+                try {
+                    if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
+                        enginePicker ??= new EnginePicker(app, 1, 1, true);
+                        enginePicker.resize(width, height);
+                        enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
+                    } else {
+                        if (!chunksPatched) {
+                            registerPickerShaderPatches(app);
+                            chunksPatched = true;
+                        }
+
+                        if (!accumPass) {
+                            initRasterAccum(width, height);
+                        } else {
+                            accumTarget.resize(width, height);
+                        }
+
+                        accumPass.init(accumTarget);
+                        accumPass.setClearColor(clearColor);
+                        accumPass.update(
+                            camera.camera,
+                            app.scene,
+                            [worldLayer],
+                            new Map<number, MeshInstance | GSplatComponent>(),
+                            false
+                        );
+                        accumPass.render();
+                    }
+
+                    updateCache(width, height);
+                } catch (e) {
+                    invalidateCache();
+                    throw e;
+                } finally {
+                    app.scene.gsplat.enableIds = prevEnableIds;
+                }
+            }
+
+            if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
+                return await enginePicker!.getWorldPointAsync(screenX, screenY);
+            }
 
             try {
                 if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
-                    enginePicker ??= new EnginePicker(app, 1, 1, true);
-                    enginePicker.resize(width, height);
-                    enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
-                    return await enginePicker.getWorldPointAsync(screenX, screenY);
+                    invalidateCache();
+                    return null;
                 }
-
-                if (!chunksPatched) {
-                    registerPickerShaderPatches(app);
-                    chunksPatched = true;
-                }
-
-                if (!accumPass) {
-                    initRasterAccum(width, height);
-                } else {
-                    accumTarget.resize(width, height);
-                }
-
-                accumPass.init(accumTarget);
-                accumPass.setClearColor(clearColor);
-                accumPass.update(
-                    camera.camera,
-                    app.scene,
-                    [worldLayer],
-                    new Map<number, MeshInstance | GSplatComponent>(),
-                    false
-                );
-                accumPass.render();
 
                 const pixels = await readTexture<Uint16Array>(accumBuffer, screenX, screenY, accumTarget);
 
@@ -431,12 +576,121 @@ class Picker {
 
                 const normalizedDepth = r / alpha;
                 return getWorldPoint(camera, screenX, screenY, width, height, normalizedDepth);
-            } finally {
-                // Pick is only invoked from user dblclick events, so concurrent invocations
-                // (which would race on enableIds) aren't a concern in practice.
-                // eslint-disable-next-line require-atomic-updates
-                app.scene.gsplat.enableIds = prevEnableIds;
+            } catch (e) {
+                invalidateCache();
+                throw e;
             }
+        };
+
+        this.pickSurface = async (x: number, y: number) => {
+            const width = Math.floor(graphicsDevice.width);
+            const height = Math.floor(graphicsDevice.height);
+
+            if (width <= 0 || height <= 0) {
+                return null;
+            }
+
+            const screenX = Math.min(width - 1, Math.max(0, Math.floor(x * width)));
+            const screenY = Math.min(height - 1, Math.max(0, Math.floor(y * height)));
+            const position = await this.pick((screenX + 0.5) / width, (screenY + 0.5) / height);
+            if (!position) {
+                return null;
+            }
+
+            const maxRadius = NORMAL_SAMPLE_RADII[NORMAL_SAMPLE_RADII.length - 1];
+            const blockX = Math.max(0, screenX - maxRadius);
+            const blockY = Math.max(0, screenY - maxRadius);
+            const blockWidth = Math.min(width - 1, screenX + maxRadius) - blockX + 1;
+            const blockHeight = Math.min(height - 1, screenY + maxRadius) - blockY + 1;
+            const rasterBlock = app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE ? null : await readRasterBlock(
+                blockX,
+                blockY,
+                blockWidth,
+                blockHeight,
+                width,
+                height
+            );
+
+            const samplePixel = (px: number, py: number) => {
+                if (px < 0 || px >= width || py < 0 || py >= height) {
+                    return Promise.resolve(null);
+                }
+
+                return rasterBlock ?
+                    Promise.resolve(rasterBlock(px, py)) :
+                    pickPixel(px, py, width, height);
+            };
+
+            const sampleRings = await Promise.all(NORMAL_SAMPLE_RADII.map((radius) => {
+                return Promise.all(NORMAL_SAMPLE_DIRECTIONS.map(([dx, dy]) => {
+                    const px = screenX + dx * radius;
+                    const py = screenY + dy * radius;
+
+                    return samplePixel(px, py);
+                }));
+            }));
+
+            const toCamera = setCameraFacingNormal(camera, position, new Vec3());
+            const candidates: Vec3[] = [];
+            const va = new Vec3();
+            const vb = new Vec3();
+            const sampleNormal = new Vec3();
+
+            sampleRings.forEach((points) => {
+                for (let i = 0; i < NORMAL_SAMPLE_DIRECTIONS.length; i++) {
+                    const pointA = points[i];
+                    const pointB = points[(i + 1) % NORMAL_SAMPLE_DIRECTIONS.length];
+                    if (!pointA || !pointB) {
+                        continue;
+                    }
+
+                    va.sub2(pointA, position);
+                    vb.sub2(pointB, position);
+                    if (va.lengthSq() <= NORMAL_EPSILON || vb.lengthSq() <= NORMAL_EPSILON) {
+                        continue;
+                    }
+
+                    // Direction order is clockwise in screen space. Screen Y points
+                    // down, so crossing next by current gives a camera-facing normal.
+                    sampleNormal.cross(vb, va);
+                    if (sampleNormal.lengthSq() <= NORMAL_EPSILON) {
+                        continue;
+                    }
+
+                    const candidate = sampleNormal.clone().normalize();
+                    if (candidate.dot(toCamera) < 0) {
+                        candidate.mulScalar(-1);
+                    }
+                    candidates.push(candidate);
+                }
+            });
+
+            const normal = new Vec3();
+            candidates.forEach((candidate) => {
+                normal.add(candidate);
+            });
+
+            if (normal.lengthSq() > NORMAL_EPSILON) {
+                normal.normalize();
+
+                const refined = new Vec3();
+                candidates.forEach((candidate) => {
+                    if (candidate.dot(normal) >= NORMAL_OUTLIER_MIN_DOT) {
+                        refined.add(candidate);
+                    }
+                });
+
+                if (refined.lengthSq() > NORMAL_EPSILON) {
+                    normal.copy(refined).normalize();
+                }
+            } else {
+                normal.copy(toCamera);
+            }
+
+            return {
+                position,
+                normal
+            };
         };
 
         this.release = () => {
@@ -448,8 +702,10 @@ class Picker {
             accumPass?.destroy();
             accumTarget?.destroy();
             accumBuffer?.destroy();
+            invalidateCache();
         };
     }
 }
 
+export type { PickSurface };
 export { Picker };

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -230,6 +230,10 @@ type PickCameraSnapshot = {
 type PickPosition = {
     position: Vec3;
     camera: PickCameraSnapshot;
+    screenX: number;
+    screenY: number;
+    width: number;
+    height: number;
     isComputeRenderer: boolean;
 };
 
@@ -543,7 +547,7 @@ class Picker {
                 const position = normalizedDepth !== null ?
                     getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth) :
                     null;
-                return position ? { position, camera: pickCamera, isComputeRenderer } : null;
+                return position ? { position, camera: pickCamera, screenX, screenY, width, height, isComputeRenderer } : null;
             }
 
             const pixels = await readTexture<Uint16Array>(accumBuffer, screenX, screenY, accumTarget);
@@ -558,7 +562,7 @@ class Picker {
 
             const normalizedDepth = r / alpha;
             const position = getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth);
-            return position ? { position, camera: pickCamera, isComputeRenderer } : null;
+            return position ? { position, camera: pickCamera, screenX, screenY, width, height, isComputeRenderer } : null;
         };
 
         const serializePick = <T>(operation: () => Promise<T>): Promise<T> => {
@@ -574,20 +578,11 @@ class Picker {
         };
 
         const pickSurface = async (x: number, y: number) => {
-            const width = Math.floor(graphicsDevice.width);
-            const height = Math.floor(graphicsDevice.height);
-
-            if (width <= 0 || height <= 0) {
-                return null;
-            }
-
-            const screenX = Math.min(width - 1, Math.max(0, Math.floor(x * width)));
-            const screenY = Math.min(height - 1, Math.max(0, Math.floor(y * height)));
-            const picked = await pickPosition((screenX + 0.5) / width, (screenY + 0.5) / height);
+            const picked = await pickPosition(x, y);
             if (!picked) {
                 return null;
             }
-            const { position } = picked;
+            const { position, screenX, screenY, width, height } = picked;
 
             if (picked.isComputeRenderer) {
                 return {

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -199,7 +199,6 @@ const pickerShaderPatchState = new WeakMap<object, PickerShaderPatchState>();
 const vec4 = new Vec4();
 const viewProjMat = new Mat4();
 const clearColor = new Color(0, 0, 0, 1);
-const MATRIX_EPSILON = 1e-6;
 const NORMAL_EPSILON = 1e-12;
 const NORMAL_OUTLIER_MIN_DOT = 0.35;
 const NORMAL_SAMPLE_RADII = [1, 2, 4, 8];
@@ -213,15 +212,6 @@ const NORMAL_SAMPLE_DIRECTIONS = [
     [0, -1],
     [1, -1]
 ] as const;
-
-const matrixEquals = (a: Float32Array<ArrayBufferLike>, b: Float32Array<ArrayBufferLike>) => {
-    for (let i = 0; i < 16; i++) {
-        if (Math.abs(a[i] - b[i]) > MATRIX_EPSILON) {
-            return false;
-        }
-    }
-    return true;
-};
 
 type PickSurface = {
     position: Vec3;
@@ -240,6 +230,7 @@ type PickCameraSnapshot = {
 type PickPosition = {
     position: Vec3;
     camera: PickCameraSnapshot;
+    isComputeRenderer: boolean;
 };
 
 // Shared buffer for half-to-float conversion
@@ -380,10 +371,6 @@ class Picker {
         let accumTarget: RenderTarget;
         let accumPass: RenderPassPicker;
         let chunksPatched = false;
-        let cacheReady = false;
-        let cacheWidth = 0;
-        let cacheHeight = 0;
-        let cacheRenderer = -1;
         const cacheCamera: PickCameraSnapshot = {
             position: new Vec3(),
             viewMatrix: new Mat4(),
@@ -434,25 +421,8 @@ class Picker {
             }) as Promise<T>;
         };
 
-        const isCacheValid = (width: number, height: number) => {
+        const updateCache = () => {
             const cam = camera.camera;
-            return cacheReady &&
-                cacheWidth === width &&
-                cacheHeight === height &&
-                cacheRenderer === app.scene.gsplat.currentRenderer &&
-                cam.nearClip === cacheCamera.nearClip &&
-                cam.farClip === cacheCamera.farClip &&
-                cam.projection === cacheCamera.projection &&
-                matrixEquals(cam.viewMatrix.data, cacheCamera.viewMatrix.data) &&
-                matrixEquals(cam.projectionMatrix.data, cacheCamera.projectionMatrix.data);
-        };
-
-        const updateCache = (width: number, height: number) => {
-            const cam = camera.camera;
-            cacheReady = true;
-            cacheWidth = width;
-            cacheHeight = height;
-            cacheRenderer = app.scene.gsplat.currentRenderer;
             cacheCamera.position.copy(camera.getPosition());
             cacheCamera.viewMatrix.copy(cam.viewMatrix);
             cacheCamera.projectionMatrix.copy(cam.projectionMatrix);
@@ -472,10 +442,6 @@ class Picker {
             };
         };
 
-        const invalidateCache = () => {
-            cacheReady = false;
-        };
-
         const readRasterBlock = async (
             blockX: number,
             blockY: number,
@@ -487,36 +453,31 @@ class Picker {
         ) => {
             const texY = graphicsDevice.isWebGL2 ? accumTarget.height - blockY - blockHeight : blockY;
 
-            try {
-                const pixels = await accumBuffer.read(blockX, texY, blockWidth, blockHeight, {
-                    renderTarget: accumTarget,
-                    immediate: true
-                }) as Uint16Array;
+            const pixels = await accumBuffer.read(blockX, texY, blockWidth, blockHeight, {
+                renderTarget: accumTarget,
+                immediate: true
+            }) as Uint16Array;
 
-                return (x: number, y: number) => {
-                    const localX = x - blockX;
-                    const localY = y - blockY;
-                    if (localX < 0 || localX >= blockWidth || localY < 0 || localY >= blockHeight) {
-                        return null;
-                    }
+            return (x: number, y: number) => {
+                const localX = x - blockX;
+                const localY = y - blockY;
+                if (localX < 0 || localX >= blockWidth || localY < 0 || localY >= blockHeight) {
+                    return null;
+                }
 
-                    const row = graphicsDevice.isWebGL2 ? blockHeight - localY - 1 : localY;
-                    const index = (row * blockWidth + localX) * 4;
-                    const r = half2Float(pixels[index]);
-                    const transmittance = half2Float(pixels[index + 3]);
-                    const alpha = 1 - transmittance;
+                const row = graphicsDevice.isWebGL2 ? blockHeight - localY - 1 : localY;
+                const index = (row * blockWidth + localX) * 4;
+                const r = half2Float(pixels[index]);
+                const transmittance = half2Float(pixels[index + 3]);
+                const alpha = 1 - transmittance;
 
-                    if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
-                        return null;
-                    }
+                if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
+                    return null;
+                }
 
-                    const normalizedDepth = r / alpha;
-                    return getWorldPoint(pickCamera, x, y, viewportWidth, viewportHeight, normalizedDepth);
-                };
-            } catch (e) {
-                invalidateCache();
-                throw e;
-            }
+                const normalizedDepth = r / alpha;
+                return getWorldPoint(pickCamera, x, y, viewportWidth, viewportHeight, normalizedDepth);
+            };
         };
 
         const pickPosition = async (x: number, y: number): Promise<PickPosition | null> => {
@@ -534,83 +495,69 @@ class Picker {
             if (!worldLayer) {
                 return null;
             }
+            const isComputeRenderer = app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE;
 
-            if (!isCacheValid(width, height)) {
-                // Enable gsplat IDs only while rendering the pick target so we
-                // don't pay the memory/perf cost between pick passes.
-                const prevEnableIds = app.scene.gsplat.enableIds;
-                app.scene.gsplat.enableIds = true;
-                try {
-                    if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
-                        enginePicker ??= new EnginePicker(app, 1, 1, true);
-                        enginePicker.resize(width, height);
-                        enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
-                    } else {
-                        if (!chunksPatched) {
-                            registerPickerShaderPatches(app);
-                            chunksPatched = true;
-                        }
-
-                        if (!accumPass) {
-                            initRasterAccum(width, height);
-                        } else {
-                            accumTarget.resize(width, height);
-                        }
-
-                        accumPass.init(accumTarget);
-                        accumPass.setClearColor(clearColor);
-                        accumPass.update(
-                            camera.camera,
-                            app.scene,
-                            [worldLayer],
-                            new Map<number, MeshInstance | GSplatComponent>(),
-                            false
-                        );
-                        accumPass.render();
+            // Enable gsplat IDs only while rendering the pick target so we
+            // don't pay the memory/perf cost between pick passes.
+            const prevEnableIds = app.scene.gsplat.enableIds;
+            app.scene.gsplat.enableIds = true;
+            try {
+                if (isComputeRenderer) {
+                    enginePicker ??= new EnginePicker(app, 1, 1, true);
+                    enginePicker.resize(width, height);
+                    enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
+                } else {
+                    if (!chunksPatched) {
+                        registerPickerShaderPatches(app);
+                        chunksPatched = true;
                     }
 
-                    updateCache(width, height);
-                } catch (e) {
-                    invalidateCache();
-                    throw e;
-                } finally {
-                    app.scene.gsplat.enableIds = prevEnableIds;
+                    if (!accumPass) {
+                        initRasterAccum(width, height);
+                    } else {
+                        accumTarget.resize(width, height);
+                    }
+
+                    accumPass.init(accumTarget);
+                    accumPass.setClearColor(clearColor);
+                    accumPass.update(
+                        camera.camera,
+                        app.scene,
+                        [worldLayer],
+                        new Map<number, MeshInstance | GSplatComponent>(),
+                        false
+                    );
+                    accumPass.render();
                 }
+
+                updateCache();
+            } finally {
+                app.scene.gsplat.enableIds = prevEnableIds;
             }
 
             const pickCamera = getCacheCameraSnapshot();
 
-            if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
+            if (isComputeRenderer) {
                 const normalizedDepth = await enginePicker!.getPointDepthAsync(screenX, screenY);
                 const position = normalizedDepth !== null ?
                     getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth) :
                     null;
-                return position ? { position, camera: pickCamera } : null;
+                return position ? { position, camera: pickCamera, isComputeRenderer } : null;
             }
 
-            try {
-                if (app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE) {
-                    invalidateCache();
-                    return null;
-                }
+            const pixels = await readTexture<Uint16Array>(accumBuffer, screenX, screenY, accumTarget);
 
-                const pixels = await readTexture<Uint16Array>(accumBuffer, screenX, screenY, accumTarget);
+            const r = half2Float(pixels[0]);
+            const transmittance = half2Float(pixels[3]);
+            const alpha = 1 - transmittance;
 
-                const r = half2Float(pixels[0]);
-                const transmittance = half2Float(pixels[3]);
-                const alpha = 1 - transmittance;
-
-                if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
-                    return null;
-                }
-
-                const normalizedDepth = r / alpha;
-                const position = getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth);
-                return position ? { position, camera: pickCamera } : null;
-            } catch (e) {
-                invalidateCache();
-                throw e;
+            if (!Number.isFinite(r) || !Number.isFinite(alpha) || alpha < 1e-6) {
+                return null;
             }
+
+            const normalizedDepth = r / alpha;
+            const position = getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth);
+            return position ? { position, camera: pickCamera, isComputeRenderer } : null;
         };
 
         this.pick = async (x: number, y: number) => {
@@ -634,12 +581,19 @@ class Picker {
             }
             const { position } = picked;
 
+            if (picked.isComputeRenderer) {
+                return {
+                    position,
+                    normal: setCameraFacingNormal(picked.camera.position, position, new Vec3())
+                };
+            }
+
             const maxRadius = NORMAL_SAMPLE_RADII[NORMAL_SAMPLE_RADII.length - 1];
             const blockX = Math.max(0, screenX - maxRadius);
             const blockY = Math.max(0, screenY - maxRadius);
             const blockWidth = Math.min(width - 1, screenX + maxRadius) - blockX + 1;
             const blockHeight = Math.min(height - 1, screenY + maxRadius) - blockY + 1;
-            const rasterBlock = app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE ? null : await readRasterBlock(
+            const rasterBlock = await readRasterBlock(
                 blockX,
                 blockY,
                 blockWidth,
@@ -654,15 +608,7 @@ class Picker {
                     return Promise.resolve(null);
                 }
 
-                if (rasterBlock) {
-                    return Promise.resolve(rasterBlock(px, py));
-                }
-
-                return enginePicker!.getPointDepthAsync(px, py).then((normalizedDepth) => {
-                    return normalizedDepth !== null ?
-                        getWorldPoint(picked.camera, px, py, width, height, normalizedDepth) :
-                        null;
-                });
+                return Promise.resolve(rasterBlock(px, py));
             };
 
             const sampleRings = await Promise.all(NORMAL_SAMPLE_RADII.map((radius) => {
@@ -746,7 +692,6 @@ class Picker {
             accumPass?.destroy();
             accumTarget?.destroy();
             accumBuffer?.destroy();
-            invalidateCache();
         };
     }
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -458,7 +458,28 @@ const initUI = (global: Global) => {
     let uiTimeout: ReturnType<typeof setTimeout> | null = null;
     let annotationVisible = false;
 
+    const isPointerCapturedMode = () => (
+        state.inputMode === 'desktop' &&
+        state.gamingControls &&
+        (state.cameraMode === 'walk' || state.cameraMode === 'fly')
+    );
+
+    const hideUI = () => {
+        if (uiTimeout) {
+            clearTimeout(uiTimeout);
+            uiTimeout = null;
+        }
+        dom.infoPanel.classList.add('hidden');
+        dom.settingsPanel.classList.add('hidden');
+        dom.walkHint.classList.add('hidden');
+        state.controlsHidden = true;
+    };
+
     const showUI = () => {
+        if (isPointerCapturedMode()) {
+            hideUI();
+            return;
+        }
         if (uiTimeout) {
             clearTimeout(uiTimeout);
         }
@@ -478,6 +499,18 @@ const initUI = (global: Global) => {
     });
 
     events.on('inputEvent', showUI);
+
+    const updateCapturedUI = () => {
+        if (isPointerCapturedMode()) {
+            hideUI();
+        } else {
+            showUI();
+        }
+    };
+
+    events.on('cameraMode:changed', updateCapturedUI);
+    events.on('inputMode:changed', updateCapturedUI);
+    events.on('gamingControls:changed', updateCapturedUI);
 
     // keep UI visible while an annotation tooltip is shown
     events.on('annotation.activate', () => {
@@ -591,7 +624,7 @@ const initUI = (global: Global) => {
     };
 
     events.on('cameraMode:changed', (value: string) => {
-        if (value === 'walk' && !walkHintShown) {
+        if (value === 'walk' && !walkHintShown && !isPointerCapturedMode()) {
             walkHintShown = true;
             dom.walkHint.textContent = getWalkHintText();
             dom.walkHint.classList.remove('hidden');

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -368,11 +368,9 @@ const initUI = (global: Global) => {
 
     const updateGamingControls = () => {
         dom.gamingControlsCheck.classList.toggle('active', state.gamingControls);
-        dom.desktopFlyClickToFly.classList.toggle('hidden', state.inputMode === 'desktop' && state.gamingControls);
-        if (state.inputMode !== 'desktop') {
-            dom.desktopClickToWalk.classList.toggle('hidden', state.gamingControls);
-            dom.desktopGamingControls.classList.toggle('hidden', !state.gamingControls);
-        }
+        dom.desktopFlyClickToFly.classList.toggle('hidden', state.gamingControls);
+        dom.desktopClickToWalk.classList.toggle('hidden', state.gamingControls);
+        dom.desktopGamingControls.classList.toggle('hidden', !state.gamingControls);
         dom.touchFlyClickToWalk.classList.toggle('hidden', state.gamingControls);
         dom.touchFlyGamingControls.classList.toggle('hidden', !state.gamingControls);
         dom.touchClickToWalk.classList.toggle('hidden', state.gamingControls);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -236,7 +236,7 @@ const initUI = (global: Global) => {
         'orbitCamera', 'flyCamera', 'fpsCamera',
         'performanceModeRow', 'performanceModeCheck', 'performanceModeOption',
         'gamingControlsDivider', 'gamingControlsRow', 'gamingControlsCheck', 'gamingControlsOption',
-        'desktopClickToWalk', 'desktopGamingControls',
+        'desktopFlyClickToFly', 'desktopClickToWalk', 'desktopGamingControls',
         'touchFlyClickToWalk', 'touchFlyGamingControls',
         'touchClickToWalk', 'touchGamingControls',
         'walkHint',
@@ -368,6 +368,7 @@ const initUI = (global: Global) => {
 
     const updateGamingControls = () => {
         dom.gamingControlsCheck.classList.toggle('active', state.gamingControls);
+        dom.desktopFlyClickToFly.classList.toggle('hidden', state.inputMode === 'desktop' && state.gamingControls);
         if (state.inputMode !== 'desktop') {
             dom.desktopClickToWalk.classList.toggle('hidden', state.gamingControls);
             dom.desktopGamingControls.classList.toggle('hidden', !state.gamingControls);
@@ -380,6 +381,7 @@ const initUI = (global: Global) => {
     };
 
     events.on('gamingControls:changed', updateGamingControls);
+    events.on('inputMode:changed', updateGamingControls);
     updateGamingControls();
 
     // AR/VR

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -393,8 +393,8 @@ class Viewer {
             this.cameraManager = new CameraManager(global, sceneBound, collision);
             applyCamera(this.cameraManager.camera);
 
-            if (collision) {
-                this.walkCursor = new WalkCursor(app, camera, collision, events, state);
+            if (!config.noui) {
+                this.walkCursor = new WalkCursor(app, camera, collision ?? null, events, state);
             }
 
             const { instance } = gsplat;

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -37,6 +37,7 @@ import { MeshCollision, VoxelCollision } from './collision';
 import { nearlyEquals } from './core/math';
 import { InputController } from './input-controller';
 import { MeshDebugOverlay } from './mesh-debug-overlay';
+import { Picker } from './picker';
 import type { ExperienceSettings, PostEffectSettings } from './settings';
 import type { Config, Global } from './types';
 import { VoxelDebugOverlay } from './voxel-debug-overlay';
@@ -162,6 +163,8 @@ class Viewer {
     inputController: InputController;
 
     cameraManager: CameraManager;
+
+    picker: Picker;
 
     annotations: Annotations;
 
@@ -364,7 +367,8 @@ class Viewer {
                 this.annotations = new Annotations(global, this.cameraFrame != null);
             }
 
-            this.inputController = new InputController(global);
+            this.picker = new Picker(app, camera);
+            this.inputController = new InputController(global, this.picker);
             this.inputController.collision = collision ?? null;
 
             state.hasCollision = !!collision;
@@ -394,7 +398,7 @@ class Viewer {
             applyCamera(this.cameraManager.camera);
 
             if (!config.noui) {
-                this.walkCursor = new WalkCursor(app, camera, collision ?? null, events, state);
+                this.walkCursor = new WalkCursor(app, camera, collision ?? null, events, state, this.picker);
             }
 
             const { instance } = gsplat;

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -81,6 +81,12 @@ const rendererTable: Record<Config['renderer'], number> = {
     'compute': GSPLAT_RENDERER_COMPUTE
 };
 
+type GSplatOctreeResourceLike = {
+    octree?: {
+        lodLevels: number;
+    } | null;
+};
+
 const tonemapTable: Record<string, number> = {
     none: TONEMAP_NONE,
     linear: TONEMAP_LINEAR,
@@ -445,7 +451,8 @@ class Viewer {
                     gsplat.lodRangeMax = 1000;
                 } else {
                     // reveal once low lod has loaded for fastest possible reveal
-                    const lodLevels = results[0].gsplat.resource?.octree?.lodLevels;
+                    const resource = results[0].gsplat.resource as GSplatOctreeResourceLike | null;
+                    const lodLevels = resource?.octree?.lodLevels;
                     if (lodLevels) {
                         gsplat.lodRangeMax = gsplat.lodRangeMin = lodLevels - 1;
                     }

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -243,6 +243,7 @@ class WalkCursor {
         };
 
         events.on('cameraMode:changed', updateActive);
+        events.on('inputMode:changed', updateActive);
         events.on('gamingControls:changed', updateActive);
 
         events.on('walkTo', () => {

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -142,6 +142,8 @@ class WalkCursor {
 
     private surfaceCursorY = 0;
 
+    private hasSurfaceCursorPosition = false;
+
     private surfaceCursorVersion = 0;
 
     private surfaceCursorPickPending = false;
@@ -329,6 +331,7 @@ class WalkCursor {
             this.cursorPath.style.display = 'none';
         }
         this.targetPath.style.display = 'none';
+        this.refreshSurfaceCursor();
     }
 
     private hideCursor() {
@@ -470,9 +473,17 @@ class WalkCursor {
     private updateSurfaceCursor(offsetX: number, offsetY: number) {
         this.surfaceCursorX = offsetX;
         this.surfaceCursorY = offsetY;
+        this.hasSurfaceCursorPosition = true;
         this.surfaceCursorVersion++;
 
         if (!this.surfaceCursorPickPending) {
+            this.processSurfaceCursor();
+        }
+    }
+
+    private refreshSurfaceCursor() {
+        if (this.hasSurfaceCursorPosition && this.shouldShowSurfaceCursor() && !this.surfaceCursorPickPending) {
+            this.surfaceCursorVersion++;
             this.processSurfaceCursor();
         }
     }

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -152,10 +152,6 @@ class WalkCursor {
 
     private onPointerLeave: () => void;
 
-    private readonly scratchX = new Float64Array(NUM_SAMPLES);
-
-    private readonly scratchY = new Float64Array(NUM_SAMPLES);
-
     private readonly outerX = new Float64Array(NUM_SAMPLES);
 
     private readonly outerY = new Float64Array(NUM_SAMPLES);
@@ -189,10 +185,11 @@ class WalkCursor {
         this.cursorPath.setAttribute('stroke', 'none');
         this.svg.appendChild(this.cursorPath);
 
-        // Walk target: filled circle
+        // Selected target cursor: same ring geometry as hover.
         this.targetPath = document.createElementNS(SVGNS, 'path');
         this.targetPath.setAttribute('fill', 'white');
-        this.targetPath.setAttribute('fill-opacity', '0.5');
+        this.targetPath.setAttribute('fill-opacity', '0.6');
+        this.targetPath.setAttribute('fill-rule', 'evenodd');
         this.targetPath.setAttribute('stroke', 'none');
         this.targetPath.style.display = 'none';
         this.svg.appendChild(this.targetPath);
@@ -415,12 +412,12 @@ class WalkCursor {
         return null;
     }
 
-    private renderCursor(pos: Vec3, normal: Vec3, smooth: boolean) {
+    private renderCursor(pos: Vec3, normal: Vec3) {
         let nx = normal.x;
         let ny = normal.y;
         let nz = normal.z;
 
-        if (smooth && this.hasSmoothedNormal) {
+        if (this.hasSmoothedNormal) {
             const t = NORMAL_SMOOTH_FACTOR;
             nx = this.smoothNx + (nx - this.smoothNx) * t;
             ny = this.smoothNy + (ny - this.smoothNy) * t;
@@ -471,7 +468,7 @@ class WalkCursor {
             }
 
             if (target) {
-                this.renderCursor(target.position, target.normal, false);
+                this.renderCursor(target.position, target.normal);
             } else {
                 this.hideCursor();
             }
@@ -504,7 +501,7 @@ class WalkCursor {
             return;
         }
 
-        this.renderCursor(target.position, target.normal, true);
+        this.renderCursor(target.position, target.normal);
     }
 
     private updateTarget() {
@@ -519,31 +516,18 @@ class WalkCursor {
             return;
         }
 
-        if (this.targetMode === 'orbit') {
-            this.projectCircle(
-                this.targetPos.x, this.targetPos.y, this.targetPos.z,
-                this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
-                CIRCLE_OUTER_RADIUS, this.outerX, this.outerY
-            );
-            this.projectCircle(
-                this.targetPos.x, this.targetPos.y, this.targetPos.z,
-                this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
-                CIRCLE_INNER_RADIUS, this.innerX, this.innerY
-            );
-
-            this.cursorPath.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
-            this.cursorPath.style.display = '';
-            this.svg.style.display = '';
-            return;
-        }
-
         this.projectCircle(
             this.targetPos.x, this.targetPos.y, this.targetPos.z,
             this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
-            CIRCLE_OUTER_RADIUS, this.scratchX, this.scratchY
+            CIRCLE_OUTER_RADIUS, this.outerX, this.outerY
+        );
+        this.projectCircle(
+            this.targetPos.x, this.targetPos.y, this.targetPos.z,
+            this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
+            CIRCLE_INNER_RADIUS, this.innerX, this.innerY
         );
 
-        this.targetPath.setAttribute('d', buildBezierRing(this.scratchX, this.scratchY));
+        this.targetPath.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
         this.targetPath.style.display = '';
         this.svg.style.display = '';
     }

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -6,7 +6,7 @@ import {
 } from 'playcanvas';
 
 import type { Collision } from './collision';
-import { Picker } from './picker';
+import type { Picker } from './picker';
 import type { State } from './types';
 
 const SVGNS = 'http://www.w3.org/2000/svg';
@@ -110,8 +110,6 @@ class WalkCursor {
 
     private targetPath: SVGPathElement;
 
-    private app: AppBase;
-
     private camera: Entity;
 
     private collision: Collision | null;
@@ -120,7 +118,7 @@ class WalkCursor {
 
     private state: State;
 
-    private picker: Picker | null = null;
+    private picker: Picker;
 
     private active = false;
 
@@ -160,18 +158,24 @@ class WalkCursor {
 
     private readonly innerY = new Float64Array(NUM_SAMPLES);
 
+    private readonly collisionTarget: CursorTarget = {
+        position: new Vec3(),
+        normal: new Vec3()
+    };
+
     constructor(
         app: AppBase,
         camera: Entity,
         collision: Collision | null,
         events: EventHandler,
-        state: State
+        state: State,
+        picker: Picker
     ) {
-        this.app = app;
         this.camera = camera;
         this.collision = collision;
         this.canvas = app.graphicsDevice.canvas as HTMLCanvasElement;
         this.state = state;
+        this.picker = picker;
 
         this.svg = document.createElementNS(SVGNS, 'svg');
         this.svg.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;overflow:visible;z-index:1';
@@ -410,10 +414,9 @@ class WalkCursor {
         }
 
         const sn = collision.querySurfaceNormal(hit.x, hit.y, hit.z, tmpV.x, tmpV.y, tmpV.z);
-        return {
-            position: new Vec3(hit.x, hit.y, hit.z),
-            normal: new Vec3(sn.nx, sn.ny, sn.nz)
-        };
+        this.collisionTarget.position.set(hit.x, hit.y, hit.z);
+        this.collisionTarget.normal.set(sn.nx, sn.ny, sn.nz);
+        return this.collisionTarget;
     }
 
     private async pickSceneTarget(offsetX: number, offsetY: number): Promise<CursorTarget | null> {
@@ -421,8 +424,6 @@ class WalkCursor {
         if (collisionTarget) {
             return collisionTarget;
         }
-
-        this.picker ??= new Picker(this.app, this.camera);
 
         const result = await this.picker.pickSurface(
             offsetX / this.canvas.clientWidth,
@@ -546,7 +547,6 @@ class WalkCursor {
     destroy() {
         this.canvas.removeEventListener('pointermove', this.onPointerMove);
         this.canvas.removeEventListener('pointerleave', this.onPointerLeave);
-        this.picker?.release();
         this.svg.remove();
     }
 }

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -208,9 +208,6 @@ class WalkCursor {
                 this.hasSmoothedNormal = false;
                 return;
             }
-            if (this.targetMode === 'orbit') {
-                this.clearTarget();
-            }
             this.updateCursor(e.offsetX, e.offsetY);
         };
 
@@ -469,7 +466,7 @@ class WalkCursor {
             this.state.gamingControls;
         return this.active && !this.walking && (
             (this.state.cameraMode === 'fly' && !flyMouseCaptured) ||
-            this.state.cameraMode === 'orbit'
+            (this.state.cameraMode === 'orbit' && this.targetMode !== 'orbit')
         );
     }
 
@@ -511,6 +508,11 @@ class WalkCursor {
 
     private updateCursor(offsetX: number, offsetY: number) {
         if (!this.active || this.walking) {
+            this.hideCursor();
+            return;
+        }
+
+        if (this.state.cameraMode === 'orbit' && this.targetMode === 'orbit') {
             this.hideCursor();
             return;
         }

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -370,6 +370,23 @@ class WalkCursor {
         }
     }
 
+    private renderRing(path: SVGPathElement, pos: Vec3, normal: Vec3) {
+        this.projectCircle(
+            pos.x, pos.y, pos.z,
+            normal.x, normal.y, normal.z,
+            CIRCLE_OUTER_RADIUS, this.outerX, this.outerY
+        );
+        this.projectCircle(
+            pos.x, pos.y, pos.z,
+            normal.x, normal.y, normal.z,
+            CIRCLE_INNER_RADIUS, this.innerX, this.innerY
+        );
+
+        path.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
+        path.style.display = '';
+        this.svg.style.display = '';
+    }
+
     private pickCollision(offsetX: number, offsetY: number): CursorTarget | null {
         if (!this.collision) {
             return null;
@@ -441,12 +458,7 @@ class WalkCursor {
         this.smoothNz = nz;
         this.hasSmoothedNormal = true;
 
-        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, CIRCLE_OUTER_RADIUS, this.outerX, this.outerY);
-        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, CIRCLE_INNER_RADIUS, this.innerX, this.innerY);
-
-        this.cursorPath.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
-        this.cursorPath.style.display = '';
-        this.svg.style.display = '';
+        this.renderRing(this.cursorPath, pos, tmpV.set(nx, ny, nz));
     }
 
     private shouldShowSurfaceCursor() {
@@ -527,20 +539,7 @@ class WalkCursor {
             return;
         }
 
-        this.projectCircle(
-            this.targetPos.x, this.targetPos.y, this.targetPos.z,
-            this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
-            CIRCLE_OUTER_RADIUS, this.outerX, this.outerY
-        );
-        this.projectCircle(
-            this.targetPos.x, this.targetPos.y, this.targetPos.z,
-            this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
-            CIRCLE_INNER_RADIUS, this.innerX, this.innerY
-        );
-
-        this.targetPath.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
-        this.targetPath.style.display = '';
-        this.svg.style.display = '';
+        this.renderRing(this.targetPath, this.targetPos, this.targetNormal);
     }
 
     destroy() {

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -230,10 +230,7 @@ class WalkCursor {
                           (state.cameraMode === 'fly' && !flyMouseCaptured) ||
                           state.cameraMode === 'orbit';
             this.surfaceCursorVersion++;
-            if (!this.active) {
-                this.cursorPath.style.display = 'none';
-                this.hasSmoothedNormal = false;
-            }
+            this.hideCursor();
             if (this.targetMode && this.targetMode !== state.cameraMode) {
                 this.walking = false;
                 this.clearTarget();

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -220,11 +220,16 @@ class WalkCursor {
         this.canvas.addEventListener('pointerleave', this.onPointerLeave);
 
         const updateActive = () => {
+            const flyMouseCaptured = (
+                state.cameraMode === 'fly' &&
+                state.inputMode === 'desktop' &&
+                state.gamingControls
+            );
             this.active = (state.cameraMode === 'walk' && !state.gamingControls) ||
-                          state.cameraMode === 'fly' ||
+                          (state.cameraMode === 'fly' && !flyMouseCaptured) ||
                           state.cameraMode === 'orbit';
             this.surfaceCursorVersion++;
-            if ((state.cameraMode !== 'walk' || state.gamingControls) && state.cameraMode !== 'fly' && state.cameraMode !== 'orbit') {
+            if (!this.active) {
                 this.cursorPath.style.display = 'none';
                 this.hasSmoothedNormal = false;
             }
@@ -445,7 +450,13 @@ class WalkCursor {
     }
 
     private shouldShowSurfaceCursor() {
-        return this.active && !this.walking && (this.state.cameraMode === 'fly' || this.state.cameraMode === 'orbit');
+        const flyMouseCaptured = this.state.cameraMode === 'fly' &&
+            this.state.inputMode === 'desktop' &&
+            this.state.gamingControls;
+        return this.active && !this.walking && (
+            (this.state.cameraMode === 'fly' && !flyMouseCaptured) ||
+            this.state.cameraMode === 'orbit'
+        );
     }
 
     private updateSurfaceCursor(offsetX: number, offsetY: number) {

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -6,6 +6,7 @@ import {
 } from 'playcanvas';
 
 import type { Collision } from './collision';
+import { Picker } from './picker';
 import type { State } from './types';
 
 const SVGNS = 'http://www.w3.org/2000/svg';
@@ -14,6 +15,36 @@ const CIRCLE_OUTER_RADIUS = 0.2;
 const CIRCLE_INNER_RADIUS = 0.17;
 const BEZIER_K = 1 / 6;
 const NORMAL_SMOOTH_FACTOR = 0.25;
+const NORMAL_SNAP_ANGLE = Math.PI / 4;
+const NORMAL_EPSILON = 1e-6;
+
+const createNormalSnapDirections = () => {
+    const result: Vec3[] = [];
+
+    for (let pitchStep = -2; pitchStep <= 2; pitchStep++) {
+        const pitch = pitchStep * NORMAL_SNAP_ANGLE;
+        const cp = Math.cos(pitch);
+        const sy = Math.sin(pitch);
+
+        if (Math.abs(cp) <= NORMAL_EPSILON) {
+            result.push(new Vec3(0, sy > 0 ? 1 : -1, 0));
+            continue;
+        }
+
+        for (let yawStep = 0; yawStep < 8; yawStep++) {
+            const yaw = yawStep * NORMAL_SNAP_ANGLE;
+            result.push(new Vec3(
+                Math.cos(yaw) * cp,
+                sy,
+                Math.sin(yaw) * cp
+            ));
+        }
+    }
+
+    return result;
+};
+
+const NORMAL_SNAP_DIRECTIONS = createNormalSnapDirections();
 
 const tmpV = new Vec3();
 const tmpScreen = new Vec3();
@@ -22,6 +53,13 @@ const bitangent = new Vec3();
 const worldPt = new Vec3();
 const up = new Vec3(0, 1, 0);
 const right = new Vec3(1, 0, 0);
+
+type CursorTarget = {
+    position: Vec3;
+    normal: Vec3;
+};
+
+type TargetMode = 'walk' | 'fly' | 'orbit';
 
 const buildBezierRing = (sx: ArrayLike<number>, sy: ArrayLike<number>) => {
     const n = sx.length;
@@ -40,6 +78,31 @@ const buildBezierRing = (sx: ArrayLike<number>, sy: ArrayLike<number>) => {
     return `${p} Z`;
 };
 
+const snapNormal = (nx: number, ny: number, nz: number, out: Vec3) => {
+    const len = Math.sqrt(nx * nx + ny * ny + nz * nz);
+    if (len <= NORMAL_EPSILON) {
+        return out.set(0, 1, 0);
+    }
+
+    const invLen = 1 / len;
+    const x = nx * invLen;
+    const y = ny * invLen;
+    const z = nz * invLen;
+    let best = NORMAL_SNAP_DIRECTIONS[0];
+    let bestDot = -Infinity;
+
+    for (let i = 0; i < NORMAL_SNAP_DIRECTIONS.length; i++) {
+        const candidate = NORMAL_SNAP_DIRECTIONS[i];
+        const dot = candidate.x * x + candidate.y * y + candidate.z * z;
+        if (dot > bestDot) {
+            bestDot = dot;
+            best = candidate;
+        }
+    }
+
+    return out.copy(best);
+};
+
 class WalkCursor {
     private svg: SVGSVGElement;
 
@@ -51,9 +114,13 @@ class WalkCursor {
 
     private camera: Entity;
 
-    private collision: Collision;
+    private collision: Collision | null;
 
     private canvas: HTMLCanvasElement;
+
+    private state: State;
+
+    private picker: Picker | null = null;
 
     private active = false;
 
@@ -63,6 +130,8 @@ class WalkCursor {
 
     private targetNormal: Vec3 | null = null;
 
+    private targetMode: TargetMode | null = null;
+
     private smoothNx = 0;
 
     private smoothNy = 1;
@@ -70,6 +139,14 @@ class WalkCursor {
     private smoothNz = 0;
 
     private hasSmoothedNormal = false;
+
+    private surfaceCursorX = 0;
+
+    private surfaceCursorY = 0;
+
+    private surfaceCursorVersion = 0;
+
+    private surfaceCursorPickPending = false;
 
     private onPointerMove: (e: PointerEvent) => void;
 
@@ -90,7 +167,7 @@ class WalkCursor {
     constructor(
         app: AppBase,
         camera: Entity,
-        collision: Collision,
+        collision: Collision | null,
         events: EventHandler,
         state: State
     ) {
@@ -98,6 +175,7 @@ class WalkCursor {
         this.camera = camera;
         this.collision = collision;
         this.canvas = app.graphicsDevice.canvas as HTMLCanvasElement;
+        this.state = state;
 
         this.svg = document.createElementNS(SVGNS, 'svg');
         this.svg.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;overflow:visible;z-index:1';
@@ -124,14 +202,19 @@ class WalkCursor {
         this.onPointerMove = (e: PointerEvent) => {
             if (e.pointerType === 'touch') return;
             if (e.buttons) {
+                this.surfaceCursorVersion++;
                 this.cursorPath.style.display = 'none';
                 this.hasSmoothedNormal = false;
                 return;
+            }
+            if (this.targetMode === 'orbit') {
+                this.clearTarget();
             }
             this.updateCursor(e.offsetX, e.offsetY);
         };
 
         this.onPointerLeave = () => {
+            this.surfaceCursorVersion++;
             this.cursorPath.style.display = 'none';
             this.hasSmoothedNormal = false;
         };
@@ -140,8 +223,18 @@ class WalkCursor {
         this.canvas.addEventListener('pointerleave', this.onPointerLeave);
 
         const updateActive = () => {
-            this.active = state.cameraMode === 'walk' &&
-                          !state.gamingControls;
+            this.active = (state.cameraMode === 'walk' && !state.gamingControls) ||
+                          state.cameraMode === 'fly' ||
+                          state.cameraMode === 'orbit';
+            this.surfaceCursorVersion++;
+            if ((state.cameraMode !== 'walk' || state.gamingControls) && state.cameraMode !== 'fly' && state.cameraMode !== 'orbit') {
+                this.cursorPath.style.display = 'none';
+                this.hasSmoothedNormal = false;
+            }
+            if (this.targetMode && this.targetMode !== state.cameraMode) {
+                this.walking = false;
+                this.clearTarget();
+            }
             if (!this.active) {
                 this.svg.style.display = 'none';
             }
@@ -167,11 +260,46 @@ class WalkCursor {
         });
 
         events.on('walkTarget:set', (pos: Vec3, normal: Vec3) => {
-            this.setTarget(pos, normal);
+            this.setTarget(pos, normal, 'walk');
         });
 
         events.on('walkTarget:clear', () => {
             this.clearTarget();
+        });
+
+        events.on('flyTo', () => {
+            this.walking = true;
+            this.cursorPath.style.display = 'none';
+            this.hasSmoothedNormal = false;
+        });
+
+        events.on('flyCancel', () => {
+            this.walking = false;
+            this.clearTarget();
+        });
+
+        events.on('flyComplete', () => {
+            this.walking = false;
+            this.clearTarget();
+        });
+
+        events.on('flyTarget:set', (pos: Vec3, normal: Vec3) => {
+            this.setTarget(pos, normal, 'fly');
+        });
+
+        events.on('flyTarget:clear', () => {
+            this.clearTarget();
+        });
+
+        events.on('orbitTarget:set', (pos: Vec3, normal: Vec3) => {
+            this.walking = false;
+            this.setTarget(pos, normal, 'orbit');
+        });
+
+        events.on('orbitTarget:clear', () => {
+            if (this.targetMode === 'orbit') {
+                this.clearTarget();
+            }
         });
 
         app.on('prerender', () => {
@@ -181,15 +309,30 @@ class WalkCursor {
         updateActive();
     }
 
-    private setTarget(pos: Vec3, normal: Vec3) {
+    private setTarget(pos: Vec3, normal: Vec3, mode: TargetMode) {
+        this.surfaceCursorVersion++;
         this.targetPos = pos.clone();
         this.targetNormal = normal.clone();
+        this.targetMode = mode;
+        this.cursorPath.style.display = 'none';
+        this.targetPath.style.display = 'none';
+        this.hasSmoothedNormal = false;
     }
 
     private clearTarget() {
+        const mode = this.targetMode;
         this.targetPos = null;
         this.targetNormal = null;
+        this.targetMode = null;
+        if (mode === 'orbit') {
+            this.cursorPath.style.display = 'none';
+        }
         this.targetPath.style.display = 'none';
+    }
+
+    private hideCursor() {
+        this.cursorPath.style.display = 'none';
+        this.hasSmoothedNormal = false;
     }
 
     private projectCircle(
@@ -198,7 +341,7 @@ class WalkCursor {
         radius: number,
         outX: Float64Array, outY: Float64Array
     ) {
-        const normal = tmpV.set(nx, ny, nz);
+        const normal = snapNormal(nx, ny, nz, tmpV);
         if (Math.abs(normal.y) < 0.99) {
             tangent.cross(normal, up).normalize();
         } else {
@@ -225,11 +368,9 @@ class WalkCursor {
         }
     }
 
-    private updateCursor(offsetX: number, offsetY: number) {
-        if (!this.active || this.walking) {
-            this.cursorPath.style.display = 'none';
-            this.hasSmoothedNormal = false;
-            return;
+    private pickCollision(offsetX: number, offsetY: number): CursorTarget | null {
+        if (!this.collision) {
+            return null;
         }
 
         const { camera, collision } = this;
@@ -245,21 +386,41 @@ class WalkCursor {
         );
 
         if (!hit) {
-            this.cursorPath.style.display = 'none';
-            this.hasSmoothedNormal = false;
-            return;
+            return null;
         }
 
-        const px = hit.x;
-        const py = hit.y;
-        const pz = hit.z;
-
         const sn = collision.querySurfaceNormal(hit.x, hit.y, hit.z, tmpV.x, tmpV.y, tmpV.z);
-        let nx = sn.nx;
-        let ny = sn.ny;
-        let nz = sn.nz;
+        return {
+            position: new Vec3(hit.x, hit.y, hit.z),
+            normal: new Vec3(sn.nx, sn.ny, sn.nz)
+        };
+    }
 
-        if (this.hasSmoothedNormal) {
+    private async pickSceneTarget(offsetX: number, offsetY: number): Promise<CursorTarget | null> {
+        const collisionTarget = this.pickCollision(offsetX, offsetY);
+        if (collisionTarget) {
+            return collisionTarget;
+        }
+
+        this.picker ??= new Picker(this.app, this.camera);
+
+        const result = await this.picker.pickSurface(
+            offsetX / this.canvas.clientWidth,
+            offsetY / this.canvas.clientHeight
+        );
+        if (result) {
+            return result;
+        }
+
+        return null;
+    }
+
+    private renderCursor(pos: Vec3, normal: Vec3, smooth: boolean) {
+        let nx = normal.x;
+        let ny = normal.y;
+        let nz = normal.z;
+
+        if (smooth && this.hasSmoothedNormal) {
             const t = NORMAL_SMOOTH_FACTOR;
             nx = this.smoothNx + (nx - this.smoothNx) * t;
             ny = this.smoothNy + (ny - this.smoothNy) * t;
@@ -278,12 +439,72 @@ class WalkCursor {
         this.smoothNz = nz;
         this.hasSmoothedNormal = true;
 
-        this.projectCircle(px, py, pz, nx, ny, nz, CIRCLE_OUTER_RADIUS, this.outerX, this.outerY);
-        this.projectCircle(px, py, pz, nx, ny, nz, CIRCLE_INNER_RADIUS, this.innerX, this.innerY);
+        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, CIRCLE_OUTER_RADIUS, this.outerX, this.outerY);
+        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, CIRCLE_INNER_RADIUS, this.innerX, this.innerY);
 
         this.cursorPath.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
         this.cursorPath.style.display = '';
         this.svg.style.display = '';
+    }
+
+    private shouldShowSurfaceCursor() {
+        return this.active && !this.walking && (this.state.cameraMode === 'fly' || this.state.cameraMode === 'orbit');
+    }
+
+    private updateSurfaceCursor(offsetX: number, offsetY: number) {
+        this.surfaceCursorX = offsetX;
+        this.surfaceCursorY = offsetY;
+        this.surfaceCursorVersion++;
+
+        if (!this.surfaceCursorPickPending) {
+            this.processSurfaceCursor();
+        }
+    }
+
+    private processSurfaceCursor() {
+        this.surfaceCursorPickPending = true;
+
+        const version = this.surfaceCursorVersion;
+        this.pickSceneTarget(this.surfaceCursorX, this.surfaceCursorY).then((target) => {
+            if (version !== this.surfaceCursorVersion || !this.shouldShowSurfaceCursor()) {
+                return;
+            }
+
+            if (target) {
+                this.renderCursor(target.position, target.normal, false);
+            } else {
+                this.hideCursor();
+            }
+        }).catch(() => {
+            if (version === this.surfaceCursorVersion) {
+                this.hideCursor();
+            }
+        }).finally(() => {
+            this.surfaceCursorPickPending = false;
+            if (version !== this.surfaceCursorVersion && this.shouldShowSurfaceCursor()) {
+                this.processSurfaceCursor();
+            }
+        });
+    }
+
+    private updateCursor(offsetX: number, offsetY: number) {
+        if (!this.active || this.walking) {
+            this.hideCursor();
+            return;
+        }
+
+        if (this.state.cameraMode === 'fly' || this.state.cameraMode === 'orbit') {
+            this.updateSurfaceCursor(offsetX, offsetY);
+            return;
+        }
+
+        const target = this.pickCollision(offsetX, offsetY);
+        if (!target) {
+            this.hideCursor();
+            return;
+        }
+
+        this.renderCursor(target.position, target.normal, true);
     }
 
     private updateTarget() {
@@ -293,8 +514,26 @@ class WalkCursor {
 
         const camPos = this.camera.getPosition();
         const dist = camPos.distance(this.targetPos);
-        if (dist < 2.0) {
+        if (this.targetMode !== 'orbit' && dist < 2.0) {
             this.targetPath.style.display = 'none';
+            return;
+        }
+
+        if (this.targetMode === 'orbit') {
+            this.projectCircle(
+                this.targetPos.x, this.targetPos.y, this.targetPos.z,
+                this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
+                CIRCLE_OUTER_RADIUS, this.outerX, this.outerY
+            );
+            this.projectCircle(
+                this.targetPos.x, this.targetPos.y, this.targetPos.z,
+                this.targetNormal.x, this.targetNormal.y, this.targetNormal.z,
+                CIRCLE_INNER_RADIUS, this.innerX, this.innerY
+            );
+
+            this.cursorPath.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
+            this.cursorPath.style.display = '';
+            this.svg.style.display = '';
             return;
         }
 
@@ -312,6 +551,7 @@ class WalkCursor {
     destroy() {
         this.canvas.removeEventListener('pointermove', this.onPointerMove);
         this.canvas.removeEventListener('pointerleave', this.onPointerLeave);
+        this.picker?.release();
         this.svg.remove();
     }
 }

--- a/src/walk-cursor.ts
+++ b/src/walk-cursor.ts
@@ -203,20 +203,25 @@ class WalkCursor {
         this.svg.style.display = 'none';
 
         this.onPointerMove = (e: PointerEvent) => {
-            if (e.pointerType === 'touch') return;
-            if (e.buttons) {
+            if (e.pointerType === 'touch') {
+                this.hasSurfaceCursorPosition = false;
                 this.surfaceCursorVersion++;
-                this.cursorPath.style.display = 'none';
-                this.hasSmoothedNormal = false;
+                this.hideCursor();
+                return;
+            }
+            if (e.buttons) {
+                this.hasSurfaceCursorPosition = false;
+                this.surfaceCursorVersion++;
+                this.hideCursor();
                 return;
             }
             this.updateCursor(e.offsetX, e.offsetY);
         };
 
         this.onPointerLeave = () => {
+            this.hasSurfaceCursorPosition = false;
             this.surfaceCursorVersion++;
-            this.cursorPath.style.display = 'none';
-            this.hasSmoothedNormal = false;
+            this.hideCursor();
         };
 
         this.canvas.addEventListener('pointermove', this.onPointerMove);
@@ -233,6 +238,9 @@ class WalkCursor {
                           state.cameraMode === 'orbit';
             this.surfaceCursorVersion++;
             this.hideCursor();
+            if (state.inputMode !== 'desktop') {
+                this.hasSurfaceCursorPosition = false;
+            }
             if (this.targetMode && this.targetMode !== state.cameraMode) {
                 this.walking = false;
                 this.clearTarget();
@@ -464,7 +472,10 @@ class WalkCursor {
         const flyMouseCaptured = this.state.cameraMode === 'fly' &&
             this.state.inputMode === 'desktop' &&
             this.state.gamingControls;
-        return this.active && !this.walking && (
+        return this.active &&
+            this.state.inputMode === 'desktop' &&
+            this.hasSurfaceCursorPosition &&
+            !this.walking && (
             (this.state.cameraMode === 'fly' && !flyMouseCaptured) ||
             (this.state.cameraMode === 'orbit' && this.targetMode !== 'orbit')
         );


### PR DESCRIPTION
## Summary

- Add click/tap target picking for fly-to and orbit focus interactions.
- Add target cursor/marker support for walk, fly, and orbit targets.
- Improve fly retargeting so selecting a new target preserves motion instead of cancelling and restarting.
- Decouple generic input interruption from fly cancellation; manual fly inputs now cancel explicitly.
- Make picker surface sampling more robust by using a consistent camera snapshot during async pick readback.