### PR TITLE
Click-nav speed modifiers, dblclick mode swaps, info panel rework

### DIFF
--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -295,10 +295,10 @@ class CameraManager {
         });
 
         // tap-to-navigate: start auto-driving the active mode toward a picked position
-        events.on('navigateTo', (position: Vec3, normal: Vec3) => {
+        events.on('navigateTo', (position: Vec3, normal: Vec3, speedMul = 1) => {
             const source = sourcesByMode[state.cameraMode];
             if (source) {
-                source.navigateTo(position);
+                source.navigateTo(position, speedMul);
                 events.fire('navTarget:set', position, normal);
             }
         });

--- a/src/cameras/fly-source.ts
+++ b/src/cameras/fly-source.ts
@@ -92,6 +92,8 @@ class FlySource implements TargetSource {
 
     private _progress = new ProgressTracker();
 
+    private _speedMul = 1;
+
     get isActive(): boolean {
         return this._target !== null;
     }
@@ -100,13 +102,16 @@ class FlySource implements TargetSource {
      * Begin auto-flying toward a world-space target position.
      *
      * @param target - The destination.
+     * @param speedMul - Forward-speed multiplier (mirrors gaming-controls
+     * shift/ctrl: 4 for boost, 0.25 for slow). Defaults to 1.
      */
-    navigateTo(target: Vec3) {
+    navigateTo(target: Vec3, speedMul = 1) {
         const wasFlying = this._target !== null;
         if (!this._target) {
             this._target = new Vec3();
         }
         this._target.copy(target);
+        this._speedMul = speedMul;
         if (!wasFlying) {
             this._yawRate = 0;
             this._pitchRate = 0;
@@ -184,7 +189,7 @@ class FlySource implements TargetSource {
         const alignmentScale = smoothstep(0.05, 0.95, alignment);
         const brakeSpeed = Math.sqrt(2 * this.moveDeceleration * activeRemainingDist);
         const arrivalSpeed = activeRemainingDist * ARRIVAL_RATE;
-        const maxSpeed = Math.min(this.flySpeed, brakeSpeed, arrivalSpeed);
+        const maxSpeed = Math.min(this.flySpeed * this._speedMul, brakeSpeed, arrivalSpeed);
 
         if (maxSpeed > this._speed) {
             this._speed = approach(this._speed, maxSpeed, this.moveAcceleration * alignmentScale * dt);

--- a/src/cameras/target-navigation.ts
+++ b/src/cameras/target-navigation.ts
@@ -10,7 +10,7 @@ import type { Camera, CameraFrame } from './camera';
 interface TargetSource {
     isActive: boolean;
     onComplete: (() => void) | null;
-    navigateTo(target: Vec3): void;
+    navigateTo(target: Vec3, speedMul?: number): void;
     cancel(): void;
     update(dt: number, camera: Camera, frame: CameraFrame): void;
 }

--- a/src/cameras/walk-source.ts
+++ b/src/cameras/walk-source.ts
@@ -56,6 +56,8 @@ class WalkSource implements TargetSource {
 
     private _progress = new ProgressTracker();
 
+    private _speedMul = 1;
+
     get isActive(): boolean {
         return this._target !== null;
     }
@@ -64,12 +66,15 @@ class WalkSource implements TargetSource {
      * Begin auto-walking toward a world-space target position.
      *
      * @param target - The destination (XZ used for navigation).
+     * @param speedMul - Forward-speed multiplier (mirrors gaming-controls
+     * shift/ctrl: 2 for run, 0.5 for crawl). Defaults to 1.
      */
-    navigateTo(target: Vec3) {
+    navigateTo(target: Vec3, speedMul = 1) {
         if (!this._target) {
             this._target = new Vec3();
         }
         this._target.copy(target);
+        this._speedMul = speedMul;
         this._progress.reset();
     }
 
@@ -127,7 +132,7 @@ class WalkSource implements TargetSource {
 
         // scale forward speed by alignment: turn in place first, then accelerate
         const alignment = Math.max(0, Math.cos(yawDiff * Math.PI / 180));
-        frame.deltas.move.append([0, 0, this.walkSpeed * dt * alignment]);
+        frame.deltas.move.append([0, 0, this.walkSpeed * this._speedMul * dt * alignment]);
     }
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -71,7 +71,7 @@
             <div id="poster"></div>
 
             <!-- SuperSplat Branding -->
-            <a id="supersplatBranding" class="hidden" target="_blank" rel="noopener noreferrer">
+            <a id="viewerBranding" class="hidden" target="_blank" rel="noopener noreferrer">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32">
                     <g class='stroke'><use href="#supersplatIcon"/></g>
                     <g class='fill'><use href="#supersplatIcon"/></g>
@@ -206,11 +206,15 @@
 
             <!-- Info Panel -->
             <div id="infoPanel" class="hidden">
-                <div id="infoPanelContent" onpointerdown="event.stopPropagation()">
-                    <div id="tabs">
-                        <div id="desktopTab" class="tab active">Desktop</div>
-                        <div id="touchTab" class="tab">Touch</div>
-                    </div>
+                <div id="infoPanelContent" onpointerdown="event.stopPropagation()" onwheel="event.stopPropagation()">
+                    <a id="viewerTitle" target="_blank" rel="noopener noreferrer">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 32 32">
+                            <g class='stroke'><use href="#supersplatIcon"/></g>
+                            <g class='fill'><use href="#supersplatIcon"/></g>
+                        </svg>
+                        <span class="title-name">SuperSplat Viewer</span>
+                        <span class="title-version">v<span id="appVersionLabel"></span></span>
+                    </a>
                     <div id="infoPanels">
                         <div id="desktopInfoPanel">
                             <div class="control-spacer"></div>
@@ -382,6 +386,10 @@
                                 </div>
                             </div>
                         </div>
+                    </div>
+                    <div id="tabs">
+                        <div id="desktopTab" class="tab active">Desktop</div>
+                        <div id="touchTab" class="tab">Touch</div>
                     </div>
                 </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -221,11 +221,11 @@
                             <h1>Orbit Mode</h1>
                             <div class="control-item">
                                 <span class="control-action">Orbit</span>
-                                <span class="control-key">Left Mouse</span>
+                                <span class="control-key">Left Click + Drag</span>
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Pan</span>
-                                <span class="control-key">Right Mouse</span>
+                                <span class="control-key">Right Click + Drag</span>
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Zoom</span>
@@ -233,7 +233,11 @@
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Set Focus</span>
-                                <span class="control-key">Click</span>
+                                <span class="control-key">Left Click</span>
+                            </div>
+                            <div class="control-item">
+                                <span class="control-action">Fly to Point</span>
+                                <span class="control-key">Double-click</span>
                             </div>
                             <div class="control-item">
                                 <span class="control-action">Frame Scene</span>
@@ -245,32 +249,68 @@
                             </div>
                             <div class="control-spacer"></div>
                             <h1>Fly Mode</h1>
-                            <div id="desktopFlyClickToFly" class="control-item">
-                                <span class="control-action">Fly To</span>
-                                <span class="control-key">Click</span>
+                            <div id="desktopFlyClickToFly">
+                                <div class="control-item">
+                                    <span class="control-action">Fly To</span>
+                                    <span class="control-key">Left Click</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Look Around</span>
+                                    <span class="control-key">Left Click + Drag</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Pan</span>
+                                    <span class="control-key">Right Click + Drag</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Move</span>
+                                    <span class="control-key">W,S,A,D</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Run / Slow</span>
+                                    <span class="control-key">Shift / Ctrl</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Focus Point</span>
+                                    <span class="control-key">Double-click</span>
+                                </div>
                             </div>
-                            <div class="control-item">
-                                <span class="control-action">Look Around</span>
-                                <span class="control-key">Click + Drag</span>
-                            </div>
-                            <div class="control-item">
-                                <span class="control-action">Pan</span>
-                                <span class="control-key">Right Mouse</span>
-                            </div>
-                            <div class="control-item">
-                                <span class="control-action">Move</span>
-                                <span class="control-key">W,S,A,D</span>
+                            <div id="desktopFlyGamingControls" class="hidden">
+                                <div class="control-item">
+                                    <span class="control-action">Look Around</span>
+                                    <span class="control-key">Mouse</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Move</span>
+                                    <span class="control-key">W,S,A,D</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Vertical</span>
+                                    <span class="control-key">Q,E</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Run / Slow</span>
+                                    <span class="control-key">Shift / Ctrl</span>
+                                </div>
                             </div>
                             <div class="control-spacer"></div>
                             <h1>Walk Mode</h1>
                             <div id="desktopClickToWalk">
                                 <div class="control-item">
                                     <span class="control-action">Walk To</span>
-                                    <span class="control-key">Click</span>
+                                    <span class="control-key">Left Click</span>
                                 </div>
                                 <div class="control-item">
                                     <span class="control-action">Look Around</span>
-                                    <span class="control-key">Click + Drag</span>
+                                    <span class="control-key">Left Click + Drag</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Run / Slow</span>
+                                    <span class="control-key">Shift / Ctrl</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Fly to Point</span>
+                                    <span class="control-key">Double-click</span>
                                 </div>
                             </div>
                             <div id="desktopGamingControls">
@@ -286,6 +326,10 @@
                                     <span class="control-action">Jump</span>
                                     <span class="control-key">Space</span>
                                 </div>
+                                <div class="control-item">
+                                    <span class="control-action">Run / Slow</span>
+                                    <span class="control-key">Shift / Ctrl</span>
+                                </div>
                             </div>
                             <div class="control-spacer"></div>
                             <h1>Mode Switching</h1>
@@ -298,11 +342,15 @@
                                 <span class="control-key">2</span>
                             </div>
                             <div class="control-item">
-                                <span class="control-action">Walk Mode</span>
+                                <span class="control-action">Toggle Walk</span>
                                 <span class="control-key">3</span>
                             </div>
                             <div class="control-item">
-                                <span class="control-action">Voxel Overlay</span>
+                                <span class="control-action">Toggle Gaming Controls</span>
+                                <span class="control-key">G</span>
+                            </div>
+                            <div class="control-item">
+                                <span class="control-action">Show Collision</span>
                                 <span class="control-key">V</span>
                             </div>
                             <div class="control-item">
@@ -312,6 +360,10 @@
                             <div class="control-item">
                                 <span class="control-action">Toggle Help</span>
                                 <span class="control-key">H</span>
+                            </div>
+                            <div class="control-item">
+                                <span class="control-action">Exit / Cancel</span>
+                                <span class="control-key">Esc</span>
                             </div>
                         </div>
                         <div id="touchInfoPanel" class="hidden">
@@ -333,6 +385,10 @@
                                 <span class="control-action">Set Focus</span>
                                 <span class="control-key">Tap</span>
                             </div>
+                            <div class="control-item">
+                                <span class="control-action">Fly to Point</span>
+                                <span class="control-key">Double-tap</span>
+                            </div>
                             <div class="control-spacer"></div>
                             <h1>Fly Mode</h1>
                             <div id="touchFlyClickToWalk">
@@ -347,6 +403,10 @@
                                 <div class="control-item">
                                     <span class="control-action">Move</span>
                                     <span class="control-key">Pinch / Two Finger Drag</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Focus Point</span>
+                                    <span class="control-key">Double-tap</span>
                                 </div>
                             </div>
                             <div id="touchFlyGamingControls" class="hidden">
@@ -369,6 +429,10 @@
                                 <div class="control-item">
                                     <span class="control-action">Look Around</span>
                                     <span class="control-key">Touch + Drag</span>
+                                </div>
+                                <div class="control-item">
+                                    <span class="control-action">Fly to Point</span>
+                                    <span class="control-key">Double-tap</span>
                                 </div>
                             </div>
                             <div id="touchGamingControls" class="hidden">

--- a/src/index.scss
+++ b/src/index.scss
@@ -108,8 +108,13 @@ button {
     text-decoration: none;
     white-space: nowrap;
     cursor: pointer;
+    transition: color 150ms ease;
 
-    color: $clr-text-light;
+    color: $clr-text;
+
+    &:hover {
+        color: $clr-text-light;
+    }
 
     > svg {
         height: 16px;
@@ -129,7 +134,7 @@ button {
             }
 
             &.fill {
-                fill: currentColor;
+                fill: $clr-accent;
                 stroke: none;
             }
         }
@@ -493,7 +498,7 @@ button {
             border-bottom: 1px solid rgba(white, 0.06);
             text-decoration: none;
             white-space: nowrap;
-            color: $clr-text-light;
+            color: $clr-text;
 
             > svg {
                 height: 20px;
@@ -510,7 +515,7 @@ button {
                     }
 
                     &.fill {
-                        fill: currentColor;
+                        fill: $clr-accent;
                         stroke: none;
                     }
                 }
@@ -533,7 +538,7 @@ button {
                 transition: color 150ms ease;
 
                 &:hover {
-                    color: $clr-accent;
+                    color: $clr-text-light;
                 }
             }
         }

--- a/src/index.scss
+++ b/src/index.scss
@@ -98,7 +98,7 @@ button {
 
 /* branding link for third-party embeds */
 
-#supersplatBranding {
+#viewerBranding {
     position: absolute;
     top: max(16px, env(safe-area-inset-top));
     left: max(16px, env(safe-area-inset-left));
@@ -469,53 +469,93 @@ button {
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        min-height: 280px;
-        min-width: 320px;
-        padding: 8px;
+        width: 360px;
+        height: min(80vh, 640px);
         border-radius: 16px;
-        border: 1px solid rgba(white, 0.08);
+        border: 1px solid rgba(white, 0.1);
         display: flex;
         flex-direction: column;
+        overflow: hidden;
 
         color: $clr-text;
-        background-color: rgba($clr-bkg, 0.8);
+        background-color: rgba($clr-bkg, 0.85);
         backdrop-filter: blur(20px);
         -webkit-backdrop-filter: blur(20px);
 
-        > #tabs {
+        > #viewerTitle {
             display: flex;
-            gap: 4px;
-            padding: 4px;
-            border-radius: 12px;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 14px 16px;
+            flex-shrink: 0;
+            background-color: rgba(black, 0.15);
+            border-bottom: 1px solid rgba(white, 0.06);
+            text-decoration: none;
+            white-space: nowrap;
+            color: $clr-text-light;
 
-            background-color: $clr-bkg-dark;
+            > svg {
+                height: 20px;
+                width: auto;
+                flex-shrink: 0;
 
-            > .tab {
-                padding: 8px 12px;
-                border-radius: 10px;
-                cursor: pointer;
-                flex-grow: 1;
-                text-align: center;
-                font-weight: bold;
+                > g {
+                    &.stroke {
+                        fill: black;
+                        stroke: black;
+                        stroke-width: 2;
+                        stroke-linejoin: round;
+                        opacity: 0.4;
+                    }
+
+                    &.fill {
+                        fill: currentColor;
+                        stroke: none;
+                    }
+                }
+            }
+
+            > .title-name {
                 font-size: 14px;
+                font-weight: bold;
+            }
 
+            > .title-version {
+                font-size: 12px;
+                font-weight: normal;
                 color: $clr-text-dark;
-                transition: background-color 250ms ease, color 250ms ease;
+                margin-left: -2px;
             }
 
-            > .tab:hover {
-                color: $clr-text-light;
-                background-color: rgba(white, 0.06);
-            }
+            &[href] {
+                cursor: pointer;
+                transition: color 150ms ease;
 
-            > .tab.active {
-                color: $clr-text-light;
-                background-color: rgba(white, 0.1);
+                &:hover {
+                    color: $clr-accent;
+                }
             }
         }
 
         > #infoPanels {
             padding: 16px;
+            flex: 1 1 auto;
+            min-height: 0;
+            overflow-y: auto;
+
+            &::-webkit-scrollbar {
+                width: 6px;
+            }
+
+            &::-webkit-scrollbar-track {
+                background: transparent;
+            }
+
+            &::-webkit-scrollbar-thumb {
+                background-color: rgba(white, 0.12);
+                border-radius: 3px;
+            }
 
             h1 {
                 font-size: 11px;
@@ -553,6 +593,34 @@ button {
 
             .control-spacer {
                 margin: 14px 0;
+            }
+        }
+
+        > #tabs {
+            display: flex;
+            gap: 24px;
+            padding: 8px 16px;
+            justify-content: center;
+            flex-shrink: 0;
+            border-top: 1px solid rgba(white, 0.06);
+
+            > .tab {
+                padding: 8px 4px;
+                border-bottom: 2px solid transparent;
+                cursor: pointer;
+                font-weight: bold;
+                font-size: 13px;
+                color: $clr-text-dark;
+                transition: color 150ms ease, border-color 150ms ease;
+            }
+
+            > .tab:hover {
+                color: $clr-text-light;
+            }
+
+            > .tab.active {
+                color: $clr-text-light;
+                border-bottom-color: $clr-accent;
             }
         }
     }

--- a/src/input/app/nav-interaction.ts
+++ b/src/input/app/nav-interaction.ts
@@ -12,6 +12,20 @@ const canTargetFly = (global: Global) => (
     !(global.state.inputMode === 'desktop' && global.state.gamingControls)
 );
 
+// Mirror gaming-controls speed modifiers: shift = run/boost, ctrl = crawl/slow.
+// Multipliers match keyboard-mouse.ts so click-nav and held-key movement feel the same.
+const computeClickSpeedMul = (event: MouseEvent | undefined, mode: string): number => {
+    if (!event) return 1;
+    if (mode === 'walk') {
+        if (event.shiftKey) return 2;
+        if (event.ctrlKey) return 0.5;
+    } else if (mode === 'fly') {
+        if (event.shiftKey) return 4;
+        if (event.ctrlKey) return 0.25;
+    }
+    return 1;
+};
+
 type PickTarget = {
     position: Vec3;
     normal: Vec3;
@@ -116,14 +130,15 @@ class NavInteraction {
         return null;
     }
 
-    private async _flyToPickedPosition(offsetX: number, offsetY: number) {
+    private async _flyToPickedPosition(offsetX: number, offsetY: number, event?: MouseEvent) {
         const global = this._global;
         if (!global || !canTargetFly(global)) return;
 
         const request = ++this._targetPickRequest;
         const target = await this._pickSceneTarget(offsetX, offsetY);
         if (target && request === this._targetPickRequest && this._global && canTargetFly(this._global)) {
-            this._global.events.fire('navigateTo', target.position, target.normal);
+            const speedMul = computeClickSpeedMul(event, this._global.state.cameraMode);
+            this._global.events.fire('navigateTo', target.position, target.normal, speedMul);
         }
     }
 
@@ -205,10 +220,11 @@ class NavInteraction {
                 if (state.cameraMode === 'walk' && !state.gamingControls) {
                     const result = this._pickCollision(this._lastPointerOffsetX, this._lastPointerOffsetY);
                     if (result) {
-                        events.fire('navigateTo', result.position, result.normal);
+                        const speedMul = computeClickSpeedMul(event, state.cameraMode);
+                        events.fire('navigateTo', result.position, result.normal, speedMul);
                     }
                 } else if (state.cameraMode === 'fly') {
-                    this._flyToPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY);
+                    this._flyToPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY, event);
                 } else if (state.cameraMode === 'orbit') {
                     this._focusPickedPosition(this._lastPointerOffsetX, this._lastPointerOffsetY);
                 }
@@ -238,7 +254,9 @@ class NavInteraction {
             events.fire('orbitTarget:set', target.position, target.normal);
         } else if (currentMode === 'orbit' || currentMode === 'walk') {
             state.cameraMode = 'fly';
-            events.fire('navigateTo', target.position, target.normal);
+            // Modifiers apply against the destination mode (fly), not the source.
+            const speedMul = computeClickSpeedMul(event, 'fly');
+            events.fire('navigateTo', target.position, target.normal, speedMul);
         }
     };
 

--- a/src/nav-cursor.ts
+++ b/src/nav-cursor.ts
@@ -179,6 +179,8 @@ class CursorRing {
 
     private svg: SVGSVGElement;
 
+    private canvas: HTMLCanvasElement;
+
     private camera: Entity;
 
     private smoothing: boolean;
@@ -203,8 +205,9 @@ class CursorRing {
 
     private readonly innerY = new Float64Array(NUM_SAMPLES);
 
-    constructor(svg: SVGSVGElement, camera: Entity, smoothing: boolean, screenPixels: number | null) {
+    constructor(svg: SVGSVGElement, canvas: HTMLCanvasElement, camera: Entity, smoothing: boolean, screenPixels: number | null) {
         this.svg = svg;
+        this.canvas = canvas;
         this.camera = camera;
         this.smoothing = smoothing;
         this.screenPixels = screenPixels;
@@ -278,7 +281,7 @@ class CursorRing {
         }
 
         const outerRadius = this.screenPixels !== null ?
-            worldRadiusForPixels(this.camera, this.svg.clientHeight || 1, pos, this.screenPixels) :
+            worldRadiusForPixels(this.camera, this.canvas.clientHeight || 1, pos, this.screenPixels) :
             BASE_OUTER_RADIUS;
         const innerRadius = outerRadius * INNER_OUTER_RATIO;
 
@@ -373,8 +376,8 @@ class NavCursor {
         this.canvas.parentElement!.appendChild(this.svg);
 
         const screenPixels = sceneSize < SMALL_SCENE_THRESHOLD ? SCREEN_OUTER_PIXELS : null;
-        this.hoverRing = new CursorRing(this.svg, camera, true, screenPixels);
-        this.targetRing = new CursorRing(this.svg, camera, false, screenPixels);
+        this.hoverRing = new CursorRing(this.svg, this.canvas, camera, true, screenPixels);
+        this.targetRing = new CursorRing(this.svg, this.canvas, camera, false, screenPixels);
 
         this.svg.style.display = 'none';
 

--- a/src/nav-cursor.ts
+++ b/src/nav-cursor.ts
@@ -14,8 +14,13 @@ import type { State } from './types';
 
 const SVGNS = 'http://www.w3.org/2000/svg';
 const NUM_SAMPLES = 12;
-const CIRCLE_OUTER_RADIUS = 0.2;
-const CIRCLE_INNER_RADIUS = 0.17;
+const BASE_OUTER_RADIUS = 0.2;
+const INNER_OUTER_RATIO = 0.17 / 0.2;
+// Scenes with halfExtents.length() below this are smaller than the walk
+// capsule (~1.5 m) — not navigable in walk mode and the world-space ring
+// engulfs the whole scene. Switch the cursor to a fixed screen size instead.
+const SMALL_SCENE_THRESHOLD = 2;
+const SCREEN_OUTER_PIXELS = 60;
 const BEZIER_K = 1 / 6;
 const NORMAL_SMOOTH_FACTOR = 0.25;
 const NORMAL_SNAP_ANGLE = Math.PI / 4;
@@ -85,6 +90,23 @@ const right = new Vec3(1, 0, 0);
 const tmpViewPos = new Vec3();
 const tmpClipVec = new Vec4();
 const tmpViewProj = new Mat4();
+
+// Compute the world-space radius such that a circle at `pos` projects to a
+// ring of `pixelDiameter` on screen. Used for the small-scene cursor mode
+// where we want a constant screen size regardless of zoom.
+const worldRadiusForPixels = (camera: Entity, canvasHeight: number, pos: Vec3, pixelDiameter: number): number => {
+    const cam = camera.camera;
+    if (cam.projection === PROJECTION_ORTHOGRAPHIC) {
+        return pixelDiameter * cam.orthoHeight / canvasHeight;
+    }
+    const camPos = camera.getPosition();
+    const dx = pos.x - camPos.x;
+    const dy = pos.y - camPos.y;
+    const dz = pos.z - camPos.z;
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    const halfFovTan = Math.tan(cam.fov * Math.PI / 360);
+    return pixelDiameter * distance * halfFovTan / canvasHeight;
+};
 
 const worldPointToDepth = (camera: PickCameraSnapshot, worldPos: Vec3) => {
     if (camera.projection === PROJECTION_ORTHOGRAPHIC) {
@@ -161,6 +183,10 @@ class CursorRing {
 
     private smoothing: boolean;
 
+    // null = world-space ring (fixed world radius, shrinks with distance);
+    // number = constant on-screen diameter in pixels.
+    private screenPixels: number | null;
+
     private smoothNx = 0;
 
     private smoothNy = 1;
@@ -177,10 +203,11 @@ class CursorRing {
 
     private readonly innerY = new Float64Array(NUM_SAMPLES);
 
-    constructor(svg: SVGSVGElement, camera: Entity, smoothing: boolean) {
+    constructor(svg: SVGSVGElement, camera: Entity, smoothing: boolean, screenPixels: number | null) {
         this.svg = svg;
         this.camera = camera;
         this.smoothing = smoothing;
+        this.screenPixels = screenPixels;
 
         this.path = document.createElementNS(SVGNS, 'path');
         this.path.setAttribute('fill', 'white');
@@ -250,8 +277,13 @@ class CursorRing {
             this.hasSmoothedNormal = true;
         }
 
-        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, CIRCLE_OUTER_RADIUS, this.outerX, this.outerY);
-        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, CIRCLE_INNER_RADIUS, this.innerX, this.innerY);
+        const outerRadius = this.screenPixels !== null ?
+            worldRadiusForPixels(this.camera, this.svg.clientHeight || 1, pos, this.screenPixels) :
+            BASE_OUTER_RADIUS;
+        const innerRadius = outerRadius * INNER_OUTER_RATIO;
+
+        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, outerRadius, this.outerX, this.outerY);
+        this.projectCircle(pos.x, pos.y, pos.z, nx, ny, nz, innerRadius, this.innerX, this.innerY);
 
         this.path.setAttribute('d', `${buildBezierRing(this.outerX, this.outerY)} ${buildBezierRing(this.innerX, this.innerY)}`);
         this.path.style.display = '';
@@ -326,7 +358,8 @@ class NavCursor {
         collision: Collision | null,
         events: EventHandler,
         state: State,
-        picker: Picker
+        picker: Picker,
+        sceneSize: number
     ) {
         this.camera = camera;
         this.collision = collision;
@@ -339,8 +372,9 @@ class NavCursor {
         this.svg.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;overflow:visible;z-index:1';
         this.canvas.parentElement!.appendChild(this.svg);
 
-        this.hoverRing = new CursorRing(this.svg, camera, true);
-        this.targetRing = new CursorRing(this.svg, camera, false);
+        const screenPixels = sceneSize < SMALL_SCENE_THRESHOLD ? SCREEN_OUTER_PIXELS : null;
+        this.hoverRing = new CursorRing(this.svg, camera, true, screenPixels);
+        this.targetRing = new CursorRing(this.svg, camera, false, screenPixels);
 
         this.svg.style.display = 'none';
 

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -201,8 +201,18 @@ const vec4 = new Vec4();
 const viewProjMat = new Mat4();
 const clearColor = new Color(0, 0, 0, 1);
 const NORMAL_EPSILON = 1e-12;
-const NORMAL_OUTLIER_MIN_DOT = 0.35;
-const NORMAL_SAMPLE_RADII = [1, 2, 4, 8];
+const NORMAL_DEGENERATE_EPSILON = 1e-20;
+// Sampling for the surface-normal estimator runs on a circular footprint of
+// fixed *world* radius, projected to pixels at the picked-point's depth.
+// Keeping the world area constant means adjacent cursor positions sample
+// almost the same world cluster, which stabilises the plane fit. The pixel
+// radius is clamped so distant picks still get enough samples and very-close
+// picks don't blow the block read.
+const NORMAL_SAMPLE_WORLD_RADIUS = 0.2;
+const NORMAL_SAMPLE_MIN_PX = 6;
+const NORMAL_SAMPLE_MAX_PX = 48;
+const NORMAL_RING_FRACTIONS = [0.3, 0.55, 0.8, 1.0];
+const NORMAL_OUTLIER_THRESHOLD = 2.5;
 const NORMAL_SAMPLE_DIRECTIONS = [
     [1, 0],
     [1, 1],
@@ -378,6 +388,134 @@ const setCameraFacingNormal = (cameraPosition: Vec3, position: Vec3, normal: Vec
     }
 
     return normal;
+};
+
+type PlaneFit = {
+    cx: number; cy: number; cz: number;
+    vx: number; vy: number; vz: number;
+};
+
+// Project a world-space radius around `pos` to its on-screen pixel radius for
+// the given camera. Uses the projection matrix's [1][1] entry (= 1/tan(fov/2)
+// for perspective, = 1/orthoHeight for orthographic) so we don't need fov or
+// orthoHeight on the snapshot.
+const worldRadiusToPixelRadius = (cam: PickCameraSnapshot, pos: Vec3, canvasHeight: number, worldRadius: number): number => {
+    const projY = cam.projectionMatrix.data[5];
+    if (cam.projection === PROJECTION_ORTHOGRAPHIC) {
+        return worldRadius * projY * canvasHeight / 2;
+    }
+    const dx = pos.x - cam.position.x;
+    const dy = pos.y - cam.position.y;
+    const dz = pos.z - cam.position.z;
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (distance < 1e-6) return Infinity;
+    return worldRadius * projY * canvasHeight / (2 * distance);
+};
+
+// Single least-squares plane fit through a cluster of 3D points. The normal
+// is the eigenvector of the smallest eigenvalue of the points' 3x3 covariance
+// matrix, computed in closed form (analytic eigendecomposition for 3x3
+// symmetric, Smith 1961). Returns null on degenerate input.
+const fitPlaneOnce = (points: Vec3[]): PlaneFit | null => {
+    const n = points.length;
+    if (n < 3) return null;
+
+    let cx = 0, cy = 0, cz = 0;
+    for (let i = 0; i < n; i++) {
+        cx += points[i].x; cy += points[i].y; cz += points[i].z;
+    }
+    cx /= n; cy /= n; cz /= n;
+
+    let cxx = 0, cxy = 0, cxz = 0, cyy = 0, cyz = 0, czz = 0;
+    for (let i = 0; i < n; i++) {
+        const dx = points[i].x - cx;
+        const dy = points[i].y - cy;
+        const dz = points[i].z - cz;
+        cxx += dx * dx; cxy += dx * dy; cxz += dx * dz;
+        cyy += dy * dy; cyz += dy * dz; czz += dz * dz;
+    }
+
+    const q = (cxx + cyy + czz) / 3;
+    const a = cxx - q, b = cyy - q, c = czz - q;
+    const p2 = a * a + b * b + c * c + 2 * (cxy * cxy + cxz * cxz + cyz * cyz);
+    if (p2 < NORMAL_DEGENERATE_EPSILON) return null;
+    const p = Math.sqrt(p2 / 6);
+    const inv = 1 / p;
+    const Bxx = a * inv, Bxy = cxy * inv, Bxz = cxz * inv;
+    const Byy = b * inv, Byz = cyz * inv, Bzz = c * inv;
+    const detB = Bxx * (Byy * Bzz - Byz * Byz) -
+                 Bxy * (Bxy * Bzz - Byz * Bxz) +
+                 Bxz * (Bxy * Byz - Byy * Bxz);
+    const r = Math.max(-1, Math.min(1, detB / 2));
+    const phi = Math.acos(r) / 3;
+    const lambdaMin = q + 2 * p * Math.cos(phi + 2 * Math.PI / 3);
+
+    const Mxx = cxx - lambdaMin, Myy = cyy - lambdaMin, Mzz = czz - lambdaMin;
+    const v1x = cxy * cyz - cxz * Myy;
+    const v1y = cxz * cxy - Mxx * cyz;
+    const v1z = Mxx * Myy - cxy * cxy;
+    const v2x = cxy * Mzz - cxz * cyz;
+    const v2y = cxz * cxz - Mxx * Mzz;
+    const v2z = Mxx * cyz - cxy * cxz;
+    const v3x = Myy * Mzz - cyz * cyz;
+    const v3y = cyz * cxz - cxy * Mzz;
+    const v3z = cxy * cyz - Myy * cxz;
+    const l1 = v1x * v1x + v1y * v1y + v1z * v1z;
+    const l2 = v2x * v2x + v2y * v2y + v2z * v2z;
+    const l3 = v3x * v3x + v3y * v3y + v3z * v3z;
+    let vx: number, vy: number, vz: number, lSq: number;
+    if (l1 >= l2 && l1 >= l3) {
+        vx = v1x; vy = v1y; vz = v1z; lSq = l1;
+    } else if (l2 >= l3) {
+        vx = v2x; vy = v2y; vz = v2z; lSq = l2;
+    } else {
+        vx = v3x; vy = v3y; vz = v3z; lSq = l3;
+    }
+    if (lSq < NORMAL_EPSILON) return null;
+    const invLen = 1 / Math.sqrt(lSq);
+    return { cx, cy, cz, vx: vx * invLen, vy: vy * invLen, vz: vz * invLen };
+};
+
+// Two-pass plane fit: first pass on all points, then drop points whose
+// distance from the fitted plane exceeds NORMAL_OUTLIER_THRESHOLD * the mean
+// residual, refit on the inliers. Sign-flips the result toward toCamera so
+// the cursor's tangent basis stays consistent. Returns false on degenerate
+// input (fewer than 3 points, collinear/coincident samples).
+const fitPlaneNormal = (points: Vec3[], toCamera: Vec3, outNormal: Vec3): boolean => {
+    const first = fitPlaneOnce(points);
+    if (!first) return false;
+
+    let residualSum = 0;
+    for (let i = 0; i < points.length; i++) {
+        const dx = points[i].x - first.cx;
+        const dy = points[i].y - first.cy;
+        const dz = points[i].z - first.cz;
+        residualSum += Math.abs(dx * first.vx + dy * first.vy + dz * first.vz);
+    }
+    const threshold = (residualSum / points.length) * NORMAL_OUTLIER_THRESHOLD;
+
+    const inliers: Vec3[] = [];
+    for (let i = 0; i < points.length; i++) {
+        const dx = points[i].x - first.cx;
+        const dy = points[i].y - first.cy;
+        const dz = points[i].z - first.cz;
+        if (Math.abs(dx * first.vx + dy * first.vy + dz * first.vz) <= threshold) {
+            inliers.push(points[i]);
+        }
+    }
+
+    let result = first;
+    if (inliers.length >= 3 && inliers.length < points.length) {
+        const refined = fitPlaneOnce(inliers);
+        if (refined) result = refined;
+    }
+
+    let { vx, vy, vz } = result;
+    if (vx * toCamera.x + vy * toCamera.y + vz * toCamera.z < 0) {
+        vx = -vx; vy = -vy; vz = -vz;
+    }
+    outNormal.set(vx, vy, vz);
+    return true;
 };
 
 class Picker {
@@ -647,12 +785,13 @@ class Picker {
                 };
             }
 
-            // Single block read serves both depth (center pixel) and normal samples (ring).
-            const maxRadius = NORMAL_SAMPLE_RADII[NORMAL_SAMPLE_RADII.length - 1];
-            const blockX = Math.max(0, screenX - maxRadius);
-            const blockY = Math.max(0, screenY - maxRadius);
-            const blockWidth = Math.min(width - 1, screenX + maxRadius) - blockX + 1;
-            const blockHeight = Math.min(height - 1, screenY + maxRadius) - blockY + 1;
+            // Single block read serves both depth (center pixel) and normal
+            // samples. Sized to the maximum possible ring pixel-radius so the
+            // dynamic ring offsets always lie inside the buffer we read.
+            const blockX = Math.max(0, screenX - NORMAL_SAMPLE_MAX_PX);
+            const blockY = Math.max(0, screenY - NORMAL_SAMPLE_MAX_PX);
+            const blockWidth = Math.min(width - 1, screenX + NORMAL_SAMPLE_MAX_PX) - blockX + 1;
+            const blockHeight = Math.min(height - 1, screenY + NORMAL_SAMPLE_MAX_PX) - blockY + 1;
             const rasterBlock = await readRasterBlock(
                 blockX,
                 blockY,
@@ -675,66 +814,34 @@ class Picker {
                 return rasterBlock(px, py);
             };
 
-            const sampleRings = NORMAL_SAMPLE_RADII.map((radius) => {
+            // Pixel radius corresponding to a fixed world radius at the
+            // picked-point's depth. Clamped so distant picks still sample
+            // enough pixels and very-close picks stay inside the block read.
+            const pixelRadius = Math.max(NORMAL_SAMPLE_MIN_PX,
+                Math.min(NORMAL_SAMPLE_MAX_PX,
+                    worldRadiusToPixelRadius(pickCamera, position, height, NORMAL_SAMPLE_WORLD_RADIUS)));
+            const ringPixelRadii = NORMAL_RING_FRACTIONS.map(f => Math.max(1, Math.round(f * pixelRadius)));
+            const sampleRings = ringPixelRadii.map((radius) => {
                 return NORMAL_SAMPLE_DIRECTIONS.map(([dx, dy]) => {
                     return samplePixel(screenX + dx * radius, screenY + dy * radius);
                 });
             });
 
             const toCamera = setCameraFacingNormal(pickCamera.position, position, new Vec3());
-            const candidates: Vec3[] = [];
-            const va = new Vec3();
-            const vb = new Vec3();
-            const sampleNormal = new Vec3();
 
-            sampleRings.forEach((points) => {
-                for (let i = 0; i < NORMAL_SAMPLE_DIRECTIONS.length; i++) {
-                    const pointA = points[i];
-                    const pointB = points[(i + 1) % NORMAL_SAMPLE_DIRECTIONS.length];
-                    if (!pointA || !pointB) {
-                        continue;
-                    }
-
-                    va.sub2(pointA, position);
-                    vb.sub2(pointB, position);
-                    if (va.lengthSq() <= NORMAL_EPSILON || vb.lengthSq() <= NORMAL_EPSILON) {
-                        continue;
-                    }
-
-                    // Direction order is clockwise in screen space. Screen Y points
-                    // down, so crossing next by current gives a camera-facing normal.
-                    sampleNormal.cross(vb, va);
-                    if (sampleNormal.lengthSq() <= NORMAL_EPSILON) {
-                        continue;
-                    }
-
-                    const candidate = sampleNormal.clone().normalize();
-                    if (candidate.dot(toCamera) < 0) {
-                        candidate.mulScalar(-1);
-                    }
-                    candidates.push(candidate);
+            // Collect every valid 3D sample: the picked position plus all ring
+            // samples that didn't fall off-screen or fail the depth read.
+            const fitPoints: Vec3[] = [position];
+            for (let i = 0; i < sampleRings.length; i++) {
+                const ring = sampleRings[i];
+                for (let j = 0; j < ring.length; j++) {
+                    const pt = ring[j];
+                    if (pt) fitPoints.push(pt);
                 }
-            });
+            }
 
             const normal = new Vec3();
-            candidates.forEach((candidate) => {
-                normal.add(candidate);
-            });
-
-            if (normal.lengthSq() > NORMAL_EPSILON) {
-                normal.normalize();
-
-                const refined = new Vec3();
-                candidates.forEach((candidate) => {
-                    if (candidate.dot(normal) >= NORMAL_OUTLIER_MIN_DOT) {
-                        refined.add(candidate);
-                    }
-                });
-
-                if (refined.lengthSq() > NORMAL_EPSILON) {
-                    normal.copy(refined).normalize();
-                }
-            } else {
+            if (!fitPlaneNormal(fitPoints, toCamera, normal)) {
                 normal.copy(toCamera);
             }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -237,7 +237,7 @@ const initUI = (global: Global) => {
         'orbitCamera', 'flyCamera', 'fpsCamera',
         'performanceModeRow', 'performanceModeCheck', 'performanceModeOption',
         'gamingControlsDivider', 'gamingControlsRow', 'gamingControlsCheck', 'gamingControlsOption',
-        'desktopFlyClickToFly', 'desktopClickToWalk', 'desktopGamingControls',
+        'desktopFlyClickToFly', 'desktopFlyGamingControls', 'desktopClickToWalk', 'desktopGamingControls',
         'touchFlyClickToWalk', 'touchFlyGamingControls',
         'touchClickToWalk', 'touchGamingControls',
         'walkHint',
@@ -373,6 +373,7 @@ const initUI = (global: Global) => {
     const updateGamingControls = () => {
         dom.gamingControlsCheck.classList.toggle('active', state.gamingControls);
         dom.desktopFlyClickToFly.classList.toggle('hidden', state.gamingControls);
+        dom.desktopFlyGamingControls.classList.toggle('hidden', !state.gamingControls);
         dom.desktopClickToWalk.classList.toggle('hidden', state.gamingControls);
         dom.desktopGamingControls.classList.toggle('hidden', !state.gamingControls);
         dom.touchFlyClickToWalk.classList.toggle('hidden', state.gamingControls);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,5 +1,6 @@
 import { EventHandler } from 'playcanvas';
 
+import { version as appVersion } from '../package.json';
 import type { Annotation } from './settings';
 import { Tooltip } from './tooltip';
 import { Global } from './types';
@@ -246,11 +247,14 @@ const initUI = (global: Global) => {
         'showCollision',
         'tooltip',
         'annotationNav', 'annotationPrev', 'annotationNext', 'annotationInfo', 'annotationNavTitle',
-        'supersplatBranding'
+        'viewerBranding', 'viewerTitle', 'appVersionLabel'
     ].reduce((acc: Record<string, HTMLElement>, id) => {
         acc[id] = document.getElementById(id);
         return acc;
     }, {});
+
+    // populate the info-panel title with the app version
+    dom.appVersionLabel.textContent = appVersion;
 
     // Remove focus from buttons after click so keyboard input isn't captured by the UI
     dom.ui.addEventListener('click', () => {
@@ -727,8 +731,9 @@ const initUI = (global: Global) => {
             viewUrl.pathname = '/view';
         }
 
-        (dom.supersplatBranding as HTMLAnchorElement).href = viewUrl.toString();
-        dom.supersplatBranding.classList.remove('hidden');
+        (dom.viewerBranding as HTMLAnchorElement).href = viewUrl.toString();
+        dom.viewerBranding.classList.remove('hidden');
+        (dom.viewerTitle as HTMLAnchorElement).href = viewUrl.toString();
     }
 };
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -398,7 +398,7 @@ class Viewer {
             applyCamera(this.cameraManager.camera);
 
             if (!config.noui) {
-                this.navCursor = new NavCursor(app, camera, collision ?? null, events, state, this.picker);
+                this.navCursor = new NavCursor(app, camera, collision ?? null, events, state, this.picker, sceneBound.halfExtents.length());
             }
 
             const { instance } = gsplat;


### PR DESCRIPTION
## Summary
- **Click-nav speed modifiers.** `WalkSource.navigateTo` and `FlySource.navigateTo` accept an optional `speedMul` multiplier. `nav-interaction.ts` reads `event.shiftKey` / `event.ctrlKey` on click and threads it through `events.fire('navigateTo', pos, normal, speedMul)` → `camera-manager.ts` → source. Multipliers mirror gaming-controls (walk: 2× / 0.5×; fly: 4× / 0.25×) so click-nav and held-key WASD feel identical. Mobile tap defaults to 1×.
- **Double-click mode swaps.** Walk+dblclick → fly + `navigateTo` toward point; orbit+dblclick → fly + `navigateTo` toward point; fly+dblclick → orbit + focus on point. The fly→orbit path fires `pick` *before* `orbitTarget:set` to avoid the orbit target being clobbered when fly source's cancellation fires `navigateComplete`.
- **Nav cursor sizing for small scenes.** Scenes with `sceneBound.halfExtents.length() < 2 m` (smaller than the walk capsule) render the cursor at a constant 60 px screen diameter instead of fixed world radius. Per-frame world radius is computed from camera distance + FOV (perspective) or `orthoHeight` (orthographic). Above the threshold, behavior is unchanged.
- **Info panel rework.** New top header `#viewerTitle` shows "SuperSplat Viewer v\<version\>" with the SuperSplat icon (orange); acts as a link to the canonical view URL when iframed cross-origin, plain text otherwise. Tabs moved to the bottom, restyled as underline indicators. Panel locked to `width: 360px; height: min(80vh, 640px)`; the controls list scrolls internally so toggling Desktop ↔ Touch keeps tabs pinned and the panel size stable. Wheel events now stop at `#infoPanelContent` so panel scroll no longer forwards to the canvas zoom.
- **Help-text accuracy.** Added Q/E vertical movement (fly+gaming), Run/Slow Shift/Ctrl rows in walk and fly, dblclick mode-swap rows in all three modes, Toggle Gaming Controls (G), Exit / Cancel (Esc). Renamed "Walk Mode 3" → "Toggle Walk", "Voxel Overlay" → "Show Collision". Added `#desktopFlyGamingControls` block parallel to the walk one so fly's Look Around correctly swaps to "Mouse" when pointer-locked. All "Click" / "Right Mouse" references normalised to "Left Click + Drag" / "Right Click + Drag".
- **Branding polish.** Old `#supersplatBranding` corner badge ID renamed to `#viewerBranding`. Both the corner badge and the info-panel title use orange logo fill, text in `$clr-text` default brightening to `$clr-text-light` on hover.
## Test plan
- [ ] `npm run lint` and `npx tsc --noEmit` pass.
- [ ] Walk: click navigates; shift+click runs (2×); ctrl+click crawls (0.5×); double-click switches to fly and flies toward point.
- [ ] Fly: click navigates; shift+click boosts (4×); ctrl+click slows (0.25×); double-click switches to orbit and focuses; Q/E vertical works in gaming controls.
- [ ] Orbit: single-click focuses; double-click switches to fly and flies toward point; orbit/pan/zoom unchanged.
- [ ] Help panel: opens cleanly; Desktop ↔ Touch toggle no longer resizes the panel; short viewports show internal scrollbar; wheel scrolls panel without zooming canvas; gaming-controls toggle swaps fly + walk help blocks correctly.
- [ ] Title shows "SuperSplat Viewer v1.22.x"; when iframed cross-origin, hovering the title brightens text and clicking opens the canonical view URL; when not iframed, title is non-interactive.
- [ ] Bee-sized scene: nav-cursor ring no longer dwarfs the object. Normal-scale scene: ring unchanged.
- [ ] No console errors in any of the above.