### PR TITLE
Drop multi-renderer WebGPU paths; use single hybrid raster+gpu-sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,11 @@ The app supports a number of URL parameters (these are subject to change):
 
 ### Renderer
 
-By default the viewer uses WebGL. The flags below opt into WebGPU rendering paths:
+By default the viewer uses WebGL. The flag below opts into WebGPU rendering:
 
 | Parameter | Description |
 | --------- | ----------- |
-| `compute` | Use the WebGPU compute renderer |
-| `gpu` | Use the WebGPU GPU sort renderer |
-| `cpu` | Use the WebGPU CPU sort renderer |
+| `webgpu` | Use the WebGPU hybrid renderer (raster + GPU radix sort) |
 | `aa` | Enable antialiasing (WebGL only) |
 | `nofx` | Disable post effects |
 | `hpr` | Override `highPrecisionRendering` from settings (`?hpr`, `?hpr=1`, `?hpr=true`, `?hpr=enable` to enable) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "concurrently": "9.2.1",
         "eslint": "9.39.4",
         "globals": "17.5.0",
-        "playcanvas": "2.18.1",
+        "playcanvas": "2.19.0-preview.0",
         "postcss": "8.5.12",
         "publint": "0.3.18",
         "rollup": "4.60.2",
@@ -2143,9 +2143,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvas": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.1.tgz",
-      "integrity": "sha512-ej1sPFR5+0YWtaVp6S1N1FVz69TQCqmrkGeRvQxZeAB1nAIcjNTHVwrZtYtWFFBmQsF40/uDLehsW5KuYC99mg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+      "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4710,9 +4710,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5085,9 +5085,9 @@
       }
     },
     "node_modules/playcanvas": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.18.1.tgz",
-      "integrity": "sha512-R+60EWFgPwgwqvnzP81sZbRfwJdL8EG5MLV+vJ+aeG6+Djt4IvpfJAHzYKRHak0I4oYtCCZwdLBygFboLBMCWQ==",
+      "version": "2.19.0-preview.0",
+      "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.19.0-preview.0.tgz",
+      "integrity": "sha512-ITNovfP8LLr8jlNGsczsQwR+lB8/omLTvofVy2YPRYIgi2WQYlllfiMu4i+6klQktwexgutz0WOLcQLGnljDkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5098,7 +5098,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "canvas": "3.2.1"
+        "canvas": "3.2.3"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "concurrently": "9.2.1",
     "eslint": "9.39.4",
     "globals": "17.5.0",
-    "playcanvas": "2.18.1",
+    "playcanvas": "2.19.0-preview.0",
     "postcss": "8.5.12",
     "publint": "0.3.18",
     "rollup": "4.60.2",

--- a/src/index.html
+++ b/src/index.html
@@ -21,20 +21,7 @@
             const settingsUrl = url.searchParams.has('settings') ? url.searchParams.get('settings') : './settings.json';
             const contentUrl = url.searchParams.has('content') ? url.searchParams.get('content') : './scene.compressed.ply';
 
-            // ?webgpu picks the best WebGPU renderer for the platform: compute on
-            // macOS (where the raster gpu-sort path stalls) and gpu-sort elsewhere.
-            // Prefer userAgentData when available, fall back to the deprecated
-            // navigator.platform / userAgent. Exclude iPad desktop mode, which
-            // reports as Mac but should not take the macOS path.
-            const uaPlatform = navigator.userAgentData?.platform || navigator.platform || navigator.userAgent || '';
-            const isIPad = navigator.maxTouchPoints > 1 && /Mac/i.test(navigator.platform || '');
-            const isMac = !isIPad && /macOS|Mac/i.test(uaPlatform);
-            const renderer =
-                url.searchParams.has('compute')  ? 'compute' :
-                url.searchParams.has('gpu-sort') ? 'gpu-sort' :
-                url.searchParams.has('cpu-sort') ? 'cpu-sort' :
-                url.searchParams.has('webgpu')   ? (isMac ? 'compute' : 'gpu-sort') :
-                                                   'webgl';
+            const renderer = url.searchParams.has('webgpu') ? 'webgpu' : 'webgl';
 
             const budgetParam = url.searchParams.get('budget');
             const budget = budgetParam !== null ? Number(budgetParam) : undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ const loadSkybox = (app: AppBase, url: string) => {
 };
 
 const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
-    const useWebGPU = config.renderer !== 'webgl';
+    const useWebGPU = config.renderer === 'webgpu';
 
     // Create the graphics device
     const device = await createGraphicsDevice(canvas, {
@@ -104,7 +104,7 @@ const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
         powerPreference: 'high-performance'
     });
 
-    console.log(`Renderer: ${device.deviceType}, ${config.renderer === 'webgl' ? 'cpu-sort' : config.renderer}`);
+    console.log(`Renderer: ${device.deviceType}`);
 
     // Set maxPixelRatio so the XR framebuffer scale factor is computed correctly.
     // Regular rendering bypasses maxPixelRatio via the custom initCanvas sizing.

--- a/src/mesh-debug-overlay.ts
+++ b/src/mesh-debug-overlay.ts
@@ -52,7 +52,7 @@ const SURFACE_ALPHA  = 0.30;
 //
 // `cameraFrameEnabled` controls how the per-vertex color is encoded so the
 // overlay looks identical between the WebGL (no CameraFrame) and
-// WebGPU/compute (CameraFrame) paths. With CameraFrame on, the engine's
+// WebGPU (CameraFrame) paths. With CameraFrame on, the engine's
 // `gammaCorrectOutput` is a no-op (GAMMA_NONE) and the StandardMaterial
 // output lands in the framebuffer as-is — so we feed the raw gray value.
 // Without CameraFrame, `gammaCorrectOutput` applies `pow(1/2.2)` to the

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,11 +1,8 @@
 /**
  * World picking for splat scenes.
  *
- * - **Compute renderer (WebGPU tiled-compute)**: uses engine `Picker` with depth enabled — expected
- *   depth is already provided by the tile-composite path.
- * - **Raster renderers (WebGL, CPU / GPU sort, etc.)**: custom `pickPS` / `gsplatPS` patch plus
- *   `RGBA16F` alpha-weighted depth accumulation, because the stock pick pass encodes splat IDs /
- *   last-fragment depth rather than expected depth.
+ * Uses a custom `pickPS` / `gsplatPS` patch plus `RGBA16F` alpha-weighted depth accumulation,
+ * because the stock pick pass encodes splat IDs / last-fragment depth rather than expected depth.
  */
 
 import {
@@ -20,10 +17,8 @@ import {
     BLENDMODE_ONE,
     BLENDMODE_ONE_MINUS_SRC_ALPHA,
     FILTER_NEAREST,
-    GSPLAT_RENDERER_COMPUTE,
     PIXELFORMAT_RGBA16F,
     PROJECTION_ORTHOGRAPHIC,
-    Picker as EnginePicker,
     Color,
     Mat4,
     RenderPassPicker,
@@ -245,7 +240,6 @@ type PickPosition = {
     screenY: number;
     width: number;
     height: number;
-    isComputeRenderer: boolean;
 };
 
 // Shared buffer for half-to-float conversion
@@ -528,7 +522,6 @@ class Picker {
     constructor(app: AppBase, camera: Entity) {
         const { graphicsDevice } = app;
 
-        let enginePicker: EnginePicker | undefined;
         let accumBuffer: Texture;
         let accumTarget: RenderTarget;
         let accumPass: RenderPassPicker;
@@ -650,7 +643,6 @@ class Picker {
         const ensureRendered = (
             width: number,
             height: number,
-            isComputeRenderer: boolean,
             worldLayer: Layer
         ) => {
             if (cameraMatches(width, height)) {
@@ -662,34 +654,28 @@ class Picker {
             const prevEnableIds = app.scene.gsplat.enableIds;
             app.scene.gsplat.enableIds = true;
             try {
-                if (isComputeRenderer) {
-                    enginePicker ??= new EnginePicker(app, 1, 1, true);
-                    enginePicker.resize(width, height);
-                    enginePicker.prepare(camera.camera, app.scene, [worldLayer]);
-                } else {
-                    if (!chunksPatched) {
-                        registerPickerShaderPatches(app);
-                        chunksPatched = true;
-                    }
-
-                    if (!accumPass) {
-                        initRasterAccum(width, height);
-                    } else if (cacheWidth !== width || cacheHeight !== height) {
-                        cacheValid = false;
-                        accumTarget.resize(width, height);
-                    }
-
-                    accumPass.init(accumTarget);
-                    accumPass.setClearColor(clearColor);
-                    accumPass.update(
-                        camera.camera,
-                        app.scene,
-                        [worldLayer],
-                        new Map<number, MeshInstance | GSplatComponent>(),
-                        false
-                    );
-                    accumPass.render();
+                if (!chunksPatched) {
+                    registerPickerShaderPatches(app);
+                    chunksPatched = true;
                 }
+
+                if (!accumPass) {
+                    initRasterAccum(width, height);
+                } else if (cacheWidth !== width || cacheHeight !== height) {
+                    cacheValid = false;
+                    accumTarget.resize(width, height);
+                }
+
+                accumPass.init(accumTarget);
+                accumPass.setClearColor(clearColor);
+                accumPass.update(
+                    camera.camera,
+                    app.scene,
+                    [worldLayer],
+                    new Map<number, MeshInstance | GSplatComponent>(),
+                    false
+                );
+                accumPass.render();
 
                 updateCache(width, height);
                 cacheValid = true;
@@ -714,12 +700,11 @@ class Picker {
 
             const screenX = Math.min(width - 1, Math.max(0, Math.floor(x * width)));
             const screenY = Math.min(height - 1, Math.max(0, Math.floor(y * height)));
-            const isComputeRenderer = app.scene.gsplat.currentRenderer === GSPLAT_RENDERER_COMPUTE;
 
-            ensureRendered(width, height, isComputeRenderer, worldLayer);
+            ensureRendered(width, height, worldLayer);
             const pickCamera = getCacheCameraSnapshot();
 
-            return { width, height, screenX, screenY, isComputeRenderer, pickCamera };
+            return { width, height, screenX, screenY, pickCamera };
         };
 
         const pickPosition = async (x: number, y: number): Promise<PickPosition | null> => {
@@ -727,15 +712,7 @@ class Picker {
             if (!sample) {
                 return null;
             }
-            const { width, height, screenX, screenY, isComputeRenderer, pickCamera } = sample;
-
-            if (isComputeRenderer) {
-                const normalizedDepth = await enginePicker!.getPointDepthAsync(screenX, screenY);
-                const position = normalizedDepth !== null ?
-                    getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth) :
-                    null;
-                return position ? { position, camera: pickCamera, screenX, screenY, width, height, isComputeRenderer } : null;
-            }
+            const { width, height, screenX, screenY, pickCamera } = sample;
 
             const pixels = await readTexture<Uint16Array>(accumBuffer, screenX, screenY, accumTarget);
 
@@ -749,7 +726,7 @@ class Picker {
 
             const normalizedDepth = r / alpha;
             const position = getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth);
-            return position ? { position, camera: pickCamera, screenX, screenY, width, height, isComputeRenderer } : null;
+            return position ? { position, camera: pickCamera, screenX, screenY, width, height } : null;
         };
 
         const serializePick = <T>(operation: () => Promise<T>): Promise<T> => {
@@ -769,21 +746,7 @@ class Picker {
             if (!sample) {
                 return null;
             }
-            const { width, height, screenX, screenY, isComputeRenderer, pickCamera } = sample;
-
-            if (isComputeRenderer) {
-                const normalizedDepth = await enginePicker!.getPointDepthAsync(screenX, screenY);
-                const position = normalizedDepth !== null ?
-                    getWorldPoint(pickCamera, screenX, screenY, width, height, normalizedDepth) :
-                    null;
-                if (!position) {
-                    return null;
-                }
-                return {
-                    position,
-                    normal: new Vec3(0, 1, 0)
-                };
-            }
+            const { width, height, screenX, screenY, pickCamera } = sample;
 
             // Single block read serves both depth (center pixel) and normal
             // samples. Sized to the maximum possible ring pixel-radius so the
@@ -860,7 +823,6 @@ class Picker {
                 unregisterPickerShaderPatches(app);
                 chunksPatched = false;
             }
-            enginePicker?.destroy();
             accumPass?.destroy();
             accumTarget?.destroy();
             accumBuffer?.destroy();

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ type Config = {
     fullload: boolean;                          // load all streaming LOD data before first frame
     aa: boolean;                                // render with antialiasing
     budget?: number;                            // override splat budget in millions (overrides platform + performanceMode table)
-    renderer: 'webgl' | 'cpu-sort' | 'gpu-sort' | 'compute';
+    renderer: 'webgl' | 'webgpu';
     heatmap: boolean;                           // render heatmap debug overlay (WebGPU only)
 };
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -24,7 +24,6 @@ import {
     GSPLAT_DEBUG_NONE,
     GSPLAT_RENDERER_RASTER_CPU_SORT,
     GSPLAT_RENDERER_RASTER_GPU_SORT,
-    GSPLAT_RENDERER_COMPUTE,
     GSplatComponent,
     platform
 } from 'playcanvas';
@@ -53,16 +52,6 @@ const patchChunk = (source: string, search: string, replacement: string, name: s
     return source.replace(search, replacement);
 };
 
-// post-effect settings used when post effects are forcibly disabled (e.g. ?nofx
-// while the compute renderer still requires CameraFrame for tile composite).
-const noPostEffects: PostEffectSettings = {
-    sharpness: { enabled: false, amount: 0 },
-    bloom: { enabled: false, intensity: 0, blurLevel: 0 },
-    grading: { enabled: false, brightness: 0, contrast: 1, saturation: 1, tint: [1, 1, 1] },
-    vignette: { enabled: false, intensity: 0, inner: 0, outer: 0, curvature: 0 },
-    fringing: { enabled: false, intensity: 0 }
-};
-
 const gammaChunkGlsl = `
 vec3 prepareOutputFromGamma(vec3 gammaColor, float depth) {
     return gammaColor;
@@ -77,9 +66,7 @@ fn prepareOutputFromGamma(gammaColor: vec3f, depth: f32) -> vec3f {
 
 const rendererTable: Record<Config['renderer'], number> = {
     'webgl': GSPLAT_RENDERER_RASTER_CPU_SORT,
-    'cpu-sort': GSPLAT_RENDERER_RASTER_CPU_SORT,
-    'gpu-sort': GSPLAT_RENDERER_RASTER_GPU_SORT,
-    'compute': GSPLAT_RENDERER_COMPUTE
+    'webgpu': GSPLAT_RENDERER_RASTER_GPU_SORT
 };
 
 type GSplatOctreeResourceLike = {
@@ -183,8 +170,7 @@ class Viewer {
         },
         wgsl: {
             gsplatOutputVS: string,
-            skyboxPS: string,
-            gsplatTileCompositePS: string
+            skyboxPS: string
         }
     };
 
@@ -211,8 +197,7 @@ class Viewer {
             },
             wgsl: {
                 gsplatOutputVS: wgsl.get('gsplatOutputVS'),
-                skyboxPS: wgsl.get('skyboxPS'),
-                gsplatTileCompositePS: wgsl.get('gsplatTileCompositePS')
+                skyboxPS: wgsl.get('skyboxPS')
             }
         };
 
@@ -546,13 +531,10 @@ class Viewer {
         // hpr override takes precedence over settings.highPrecisionRendering
         const highPrecisionRendering = config.hpr ?? settings.highPrecisionRendering;
 
-        // compute renderer requires CameraFrame to perform tile composite output,
-        // so it must be enabled even when post effects are suppressed via ?nofx.
-        const computeRequiresCameraFrame = config.renderer === 'compute';
         const postFxRequested = !config.nofx &&
             (anyPostEffectEnabled(postEffectSettings) || highPrecisionRendering);
 
-        const enableCameraFrame = !app.xr.active && (computeRequiresCameraFrame || postFxRequested);
+        const enableCameraFrame = !app.xr.active && postFxRequested;
 
         if (enableCameraFrame) {
             // create instance
@@ -564,8 +546,7 @@ class Viewer {
             cameraFrame.enabled = true;
             cameraFrame.rendering.toneMapping = tonemapTable[settings.tonemapping];
             cameraFrame.rendering.renderFormats = highPrecisionRendering ? [PIXELFORMAT_RGBA16F, PIXELFORMAT_RGBA32F] : [];
-            cameraFrame.rendering.sceneDepthMap = config.renderer === 'compute'; // needed for annotations
-            applyPostEffectSettings(cameraFrame, postFxRequested ? postEffectSettings : noPostEffects);
+            applyPostEffectSettings(cameraFrame, postEffectSettings);
             cameraFrame.update();
 
             // force gsplat shader to write gamma-space colors
@@ -591,17 +572,6 @@ class Viewer {
                 )
             );
 
-            // force tile composite shader to write gamma-space colors (inline pow replaces the
-            // gammaCorrectOutput call which is a no-op under CameraFrame's GAMMA_NONE)
-            ShaderChunks.get(app.graphicsDevice, 'wgsl').set('gsplatTileCompositePS',
-                patchChunk(
-                    this.origChunks.wgsl.gsplatTileCompositePS,
-                    'gammaCorrectOutput(toneMap(linear.rgb))',
-                    'pow(toneMap(linear.rgb) + 0.0000001, vec3f(1.0 / 2.2))',
-                    'wgsl gsplatTileCompositePS gamma override'
-                )
-            );
-
             // ensure the final compose blit doesn't perform linear->gamma conversion.
             RenderTarget.prototype.isColorBufferSrgb = function (index) {
                 return this === app.graphicsDevice.backBuffer ? true : origIsColorBufferSrgb.call(this, index);
@@ -620,7 +590,6 @@ class Viewer {
             ShaderChunks.get(app.graphicsDevice, 'wgsl').set('gsplatOutputVS', this.origChunks.wgsl.gsplatOutputVS);
             ShaderChunks.get(app.graphicsDevice, 'glsl').set('skyboxPS', this.origChunks.glsl.skyboxPS);
             ShaderChunks.get(app.graphicsDevice, 'wgsl').set('skyboxPS', this.origChunks.wgsl.skyboxPS);
-            ShaderChunks.get(app.graphicsDevice, 'wgsl').set('gsplatTileCompositePS', this.origChunks.wgsl.gsplatTileCompositePS);
 
             // restore original isColorBufferSrgb behavior
             RenderTarget.prototype.isColorBufferSrgb = origIsColorBufferSrgb;


### PR DESCRIPTION
## Summary

Collapses the four WebGPU renderer flags (`compute` / `gpu-sort` / `cpu-sort` / `webgpu`) down to a single `?webgpu` flag now that engine `2.19.0-preview.0` makes the raster GPU-sort path viable on macOS — the platform was previously routed to the compute renderer because gpu-sort stalled there.

## Changes

- Removes the macOS UA sniff in `index.html`; `?webgpu` now maps directly to the hybrid raster+gpu-sort renderer on every platform.
- Drops the engine `Picker` branch in `picker.ts`; the custom `pickPS`/`gsplatPS` + RGBA16F accumulation path now serves all renderers.
- Removes compute-only scaffolding in `viewer.ts`: `GSPLAT_RENDERER_COMPUTE`, `noPostEffects`, the `gsplatTileCompositePS` chunk patch, and the `computeRequiresCameraFrame` branch that forced CameraFrame under `?nofx`.
- Simplifies `Config['renderer']` to `'webgl' | 'webgpu'` and updates the README flag table.
- Bumps `playcanvas` to `2.19.0-preview.0`.

## Test plan

- [ ] `?webgpu` on macOS — scene renders, no stalls.
- [ ] `?webgpu` picker on macOS — click-nav and info panel still work.
- [ ] `?webgpu&nofx` on macOS — rendering looks correct without CameraFrame.
- [ ] Windows/Linux WebGPU — unchanged behavior.
- [ ] Default WebGL path on a WebGPU-incapable browser.