### PR TITLE
Match fly two-finger touch to orbit and hide unavailable collision help row

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -354,7 +354,7 @@
                                 <span class="control-action">Toggle Gaming Controls</span>
                                 <span class="control-key">G</span>
                             </div>
-                            <div class="control-item">
+                            <div id="desktopShowCollisionHelp" class="control-item hidden">
                                 <span class="control-action">Show Collision</span>
                                 <span class="control-key">V</span>
                             </div>

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -1,4 +1,4 @@
-import { math, MultiTouchSource, Vec3 } from 'playcanvas';
+import { MultiTouchSource, Vec3 } from 'playcanvas';
 
 import type { Global } from '../../types';
 import {
@@ -11,7 +11,6 @@ import type { CameraInputFrame, InputDevice, UpdateContext } from '../shared';
 const tmpV = new Vec3();
 const orbitMove = new Vec3();
 const flyMoveTmp = new Vec3();
-const flyTouchPan = new Vec3();
 const pinchMoveTmp = new Vec3();
 const orbitRotate = new Vec3();
 const flyRotate = new Vec3();
@@ -25,12 +24,6 @@ class TouchDevice implements InputDevice {
 
     touchRotateSensitivity: number = 1.5;
 
-    touchPinchMoveSensitivity: number = 1.5;
-
-    pinchVelocitySensitivity: number = 0.006;
-
-    panVelocitySensitivity: number = 0.005;
-
     private _source = new MultiTouchSource();
 
     private _global: Global | null = null;
@@ -40,12 +33,6 @@ class TouchDevice implements InputDevice {
 
     /** UI joystick value [x, y], -1..1. */
     private _joystick: [number, number] = [0, 0];
-
-    /** Smoothed forward/back velocity from pinch gesture (-1..1). */
-    private _pinchVelocity = 0;
-
-    /** Smoothed strafe/vertical velocity from two-finger pan, -1..1 each. */
-    private _panVelocity: [number, number] = [0, 0];
 
     /** Tap-detection state — touch count, max touches, and accumulated movement. */
     private _tapTouches = 0;
@@ -138,50 +125,34 @@ class TouchDevice implements InputDevice {
             this._tapMaxTouches = 0;
         }
 
-        // smoothed velocities for fly/walk first-person motion (non-gaming)
-        if (isFirstPerson && !gamingControls && this._touchCount > 1) {
-            // pinch[0] = oldDist - newDist: negative when spreading,
-            // positive when closing. Spreading = forward → subtract.
-            this._pinchVelocity -= pinch[0] * this.pinchVelocitySensitivity;
-            this._pinchVelocity = math.clamp(this._pinchVelocity, -1.0, 1.0);
-            this._panVelocity[0] += touch[0] * this.panVelocitySensitivity;
-            this._panVelocity[0] = math.clamp(this._panVelocity[0], -1.0, 1.0);
-            this._panVelocity[1] += touch[1] * this.panVelocitySensitivity;
-            this._panVelocity[1] = math.clamp(this._panVelocity[1], -1.0, 1.0);
-        } else if (isFirstPerson && this._touchCount <= 1) {
-            this._pinchVelocity = 0;
-            this._panVelocity[0] = 0;
-            this._panVelocity[1] = 0;
-        }
-
         const orbit = isOrbit ? 1 : 0;
         const fly = isFirstPerson ? 1 : 0;
         const double = this._touchCount > 1 ? 1 : 0;
         const orbitFactor = isFirstPerson ? cameraComponent.fov / 120 : 1;
         const dragInvert = (isFirstPerson && !gamingControls) ? -1 : 1;
+        // Fly contributes to the direct two-finger model only outside gaming
+        // controls (gaming uses the joystick instead).
+        const directFly = fly * (gamingControls ? 0 : 1);
 
         const { deltas } = frame;
 
         // move
         const v = tmpV.set(0, 0, 0);
-        // two-finger orbit-pan when in orbit mode (single touch is rotate, double is pan)
+        // Two-finger pan: orbit pans the target, fly strafes/rises in the
+        // camera basis. Identical 1:1 screen-space mapping in both modes so
+        // dragging feels the same — what your fingers move, the camera moves.
         screenToWorld(cameraComponent, touch[0], touch[1], distance, orbitMove);
-        v.add(orbitMove.mulScalar(orbit * double));
+        v.add(orbitMove.mulScalar((orbit + directFly) * double));
         if (gamingControls) {
             // joystick UI drives strafe + forward/back in fly/walk
             flyMoveTmp.set(this._joystick[0], 0, -this._joystick[1]);
             v.add(flyMoveTmp.mulScalar(fly * this.moveSpeed * dt));
-        } else {
-            // smoothed pan velocity → strafe (X) and vertical (Y, fly only)
-            flyTouchPan.set(this._panVelocity[0], isWalk ? 0 : -this._panVelocity[1], 0);
-            v.add(flyTouchPan.mulScalar(fly * this.touchPinchMoveSensitivity * this.moveSpeed * dt));
-            // smoothed pinch velocity → forward/back
-            flyMoveTmp.set(0, 0, this._pinchVelocity);
-            v.add(flyMoveTmp.mulScalar(fly * this.touchPinchMoveSensitivity * this.moveSpeed * dt));
         }
-        // raw pinch for orbit-mode zoom
-        pinchMoveTmp.set(0, 0, pinch[0]);
-        v.add(pinchMoveTmp.mulScalar(orbit * double * this.pinchSpeed * DISPLACEMENT_SCALE));
+        // Two-finger pinch z: orbit interprets +z as "farther from target"
+        // (close-pinch = +pinch[0] = zoom out). Fly interprets +z as "forward"
+        // so spreading (pinch[0] < 0) should move forward — flip the sign.
+        pinchMoveTmp.set(0, 0, (orbit - directFly) * pinch[0]);
+        v.add(pinchMoveTmp.mulScalar(double * this.pinchSpeed * DISPLACEMENT_SCALE));
         // tap-to-jump in walk + gaming controls
         if (isWalk && this._tapJump) {
             v.y = 1;

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -130,33 +130,34 @@ class TouchDevice implements InputDevice {
         const double = this._touchCount > 1 ? 1 : 0;
         const orbitFactor = isFirstPerson ? cameraComponent.fov / 120 : 1;
         const dragInvert = (isFirstPerson && !gamingControls) ? -1 : 1;
-        // Fly contributes to the direct two-finger model only outside gaming
-        // controls (gaming uses the joystick instead).
-        const directFly = fly * (gamingControls ? 0 : 1);
+        // First-person modes (fly and walk) opt into the direct two-finger
+        // model only outside gaming controls (gaming uses the joystick).
+        const directFirstPerson = fly * (gamingControls ? 0 : 1);
 
         const { deltas } = frame;
 
         // move
         const v = tmpV.set(0, 0, 0);
-        // Two-finger pan: orbit pans the target, fly strafes/rises in the
-        // camera basis. Identical 1:1 screen-space mapping in both modes so
-        // dragging feels the same — what your fingers move, the camera moves.
-        // Walk reuses the same path for strafe but must keep y at 0 since
+        // Two-finger pan: orbit pans the target; fly strafes/rises in the
+        // camera basis; walk strafes along the ground plane. Identical 1:1
+        // screen-space mapping in every mode so dragging feels the same —
+        // what your fingers move, the camera moves. Walk zeros y because
         // WalkController treats any nonzero move[1] as a jump trigger.
         screenToWorld(cameraComponent, touch[0], touch[1], distance, orbitMove);
         if (isWalk) {
             orbitMove.y = 0;
         }
-        v.add(orbitMove.mulScalar((orbit + directFly) * double));
+        v.add(orbitMove.mulScalar((orbit + directFirstPerson) * double));
         if (gamingControls) {
             // joystick UI drives strafe + forward/back in fly/walk
             flyMoveTmp.set(this._joystick[0], 0, -this._joystick[1]);
             v.add(flyMoveTmp.mulScalar(fly * this.moveSpeed * dt));
         }
         // Two-finger pinch z: orbit interprets +z as "farther from target"
-        // (close-pinch = +pinch[0] = zoom out). Fly interprets +z as "forward"
-        // so spreading (pinch[0] < 0) should move forward — flip the sign.
-        pinchMoveTmp.set(0, 0, (orbit - directFly) * pinch[0]);
+        // (close-pinch = +pinch[0] = zoom out). First-person modes interpret
+        // +z as "forward", so spreading (pinch[0] < 0) should move forward —
+        // flip the sign there.
+        pinchMoveTmp.set(0, 0, (orbit - directFirstPerson) * pinch[0]);
         v.add(pinchMoveTmp.mulScalar(double * this.pinchSpeed * DISPLACEMENT_SCALE));
         // tap-to-jump in walk + gaming controls
         if (isWalk && this._tapJump) {

--- a/src/input/devices/touch.ts
+++ b/src/input/devices/touch.ts
@@ -141,7 +141,12 @@ class TouchDevice implements InputDevice {
         // Two-finger pan: orbit pans the target, fly strafes/rises in the
         // camera basis. Identical 1:1 screen-space mapping in both modes so
         // dragging feels the same — what your fingers move, the camera moves.
+        // Walk reuses the same path for strafe but must keep y at 0 since
+        // WalkController treats any nonzero move[1] as a jump trigger.
         screenToWorld(cameraComponent, touch[0], touch[1], distance, orbitMove);
+        if (isWalk) {
+            orbitMove.y = 0;
+        }
         v.add(orbitMove.mulScalar((orbit + directFly) * double));
         if (gamingControls) {
             // joystick UI drives strafe + forward/back in fly/walk

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -244,7 +244,7 @@ const initUI = (global: Global) => {
         'reset', 'frame',
         'loadingText', 'loadingBar',
         'joystickBase', 'joystick',
-        'showCollision',
+        'showCollision', 'desktopShowCollisionHelp',
         'tooltip',
         'annotationNav', 'annotationPrev', 'annotationNext', 'annotationInfo', 'annotationNavTitle',
         'viewerBranding', 'viewerTitle', 'appVersionLabel'
@@ -652,9 +652,10 @@ const initUI = (global: Global) => {
         dom.flyCamera.classList.toggle('right', !value);
     });
 
-    // Collision overlay toggle (only visible when overlay is available)
+    // Collision overlay toggle + matching help-panel row (only visible when overlay is available)
     events.on('hasCollisionOverlay:changed', (value: boolean) => {
         dom.showCollision.classList.toggle('hidden', !value);
+        dom.desktopShowCollisionHelp.classList.toggle('hidden', !value);
     });
 
     dom.showCollision.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Two-finger touch in fly mode now uses the same direct 1:1 screen-space pan and raw pinch mapping as orbit mode. Removed the smoothed `_panVelocity` / `_pinchVelocity` accumulators (and their sensitivity fields) so finger motion produces immediate, proportional camera motion that stops the instant fingers stop — matching orbit's feel. Pinch z-sign is flipped for fly since +z is forward there vs. "farther from target" in orbit.
- The desktop help row "Show Collision — V" was rendered unconditionally even when no overlay is available (e.g. voxel collision on the WebGL2 renderer, where the voxel path is gated to WebGPU). The row now mirrors the toolbar button and only appears when `hasCollisionOverlay` is true, so the help never advertises a no-op shortcut.
## Test plan
- [ ] Orbit mode (`1`): two-finger drag pans target 1:1, pinch zooms — unchanged.
- [ ] Fly mode (`2`, non-gaming): two-finger drag strafes/rises 1:1 and stops immediately on release; pinch spread = forward, close = back.
- [ ] Fly mode with gaming controls (`G`): joystick path still works; two-finger gestures inert as before.
- [ ] Help panel ("H"): "Show Collision V" row is absent with no collision data, absent with voxel collision on `?renderer=webgl`, present with mesh collision on WebGL2, present with voxel collision on WebGPU. Row visibility matches the toolbar button in every case.
- [ ] `npm run type:check` and `npm run lint` clean.