### PR TITLE
Add developer debug panel

### DIFF
--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -50,8 +50,20 @@ const createFrameCamera = (bbox: BoundingBox, fov: number) => {
     );
 };
 
+type CameraStateSnapshot = {
+    position: [number, number, number];
+    angles: [number, number, number];
+    distance: number;
+    fov: number;
+    mode: CameraMode;
+};
+
 class CameraManager {
     update: (deltaTime: number, cameraFrame: CameraFrame) => void;
+
+    getCameraState: () => CameraStateSnapshot;
+
+    setCameraState: (snapshot: CameraStateSnapshot) => void;
 
     // holds the camera state
     camera = new Camera();
@@ -144,6 +156,31 @@ class CameraManager {
         const startTransition = () => {
             from.copy(this.camera);
             transitionTimer = 0;
+        };
+
+        this.getCameraState = () => ({
+            position: [this.camera.position.x, this.camera.position.y, this.camera.position.z],
+            angles: [this.camera.angles.x, this.camera.angles.y, this.camera.angles.z],
+            distance: this.camera.distance,
+            fov: this.camera.fov,
+            mode: state.cameraMode
+        });
+
+        this.setCameraState = (snapshot: CameraStateSnapshot) => {
+            this.camera.position.set(snapshot.position[0], snapshot.position[1], snapshot.position[2]);
+            this.camera.angles.set(snapshot.angles[0], snapshot.angles[1], snapshot.angles[2]);
+            this.camera.distance = snapshot.distance;
+            this.camera.fov = snapshot.fov;
+
+            if (state.cameraMode === snapshot.mode) {
+                getController(snapshot.mode).onEnter(this.camera);
+            } else {
+                state.cameraMode = snapshot.mode;
+            }
+            target.copy(this.camera);
+            transitionTimer = 1;
+
+            global.app.renderNextFrame = true;
         };
 
         // application update
@@ -330,3 +367,4 @@ class CameraManager {
 }
 
 export { CameraManager, isWalkAllowed };
+export type { CameraStateSnapshot };

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -50,20 +50,14 @@ const createFrameCamera = (bbox: BoundingBox, fov: number) => {
     );
 };
 
-type CameraStateSnapshot = {
-    position: [number, number, number];
-    angles: [number, number, number];
-    distance: number;
-    fov: number;
-    mode: CameraMode;
-};
-
 class CameraManager {
     update: (deltaTime: number, cameraFrame: CameraFrame) => void;
 
-    getCameraState: () => CameraStateSnapshot;
-
-    setCameraState: (snapshot: CameraStateSnapshot) => void;
+    // Re-seed the active controller from the current camera pose and
+    // cancel any in-progress transition lerp. Use after externally
+    // mutating `camera` and/or `state.cameraMode` to make the change
+    // visible instantly.
+    snap: () => void;
 
     // holds the camera state
     camera = new Camera();
@@ -158,28 +152,10 @@ class CameraManager {
             transitionTimer = 0;
         };
 
-        this.getCameraState = () => ({
-            position: [this.camera.position.x, this.camera.position.y, this.camera.position.z],
-            angles: [this.camera.angles.x, this.camera.angles.y, this.camera.angles.z],
-            distance: this.camera.distance,
-            fov: this.camera.fov,
-            mode: state.cameraMode
-        });
-
-        this.setCameraState = (snapshot: CameraStateSnapshot) => {
-            this.camera.position.set(snapshot.position[0], snapshot.position[1], snapshot.position[2]);
-            this.camera.angles.set(snapshot.angles[0], snapshot.angles[1], snapshot.angles[2]);
-            this.camera.distance = snapshot.distance;
-            this.camera.fov = snapshot.fov;
-
-            if (state.cameraMode === snapshot.mode) {
-                getController(snapshot.mode).onEnter(this.camera);
-            } else {
-                state.cameraMode = snapshot.mode;
-            }
+        this.snap = () => {
+            getController(state.cameraMode).onEnter(this.camera);
             target.copy(this.camera);
             transitionTimer = 1;
-
             global.app.renderNextFrame = true;
         };
 
@@ -367,4 +343,3 @@ class CameraManager {
 }
 
 export { CameraManager, isWalkAllowed };
-export type { CameraStateSnapshot };

--- a/src/debug/camera-state.ts
+++ b/src/debug/camera-state.ts
@@ -1,0 +1,36 @@
+import type { CameraManager } from '../camera-manager';
+import type { State } from '../types';
+
+type CameraStateSnapshot = {
+    position: [number, number, number];
+    angles: [number, number, number];
+    distance: number;
+    fov: number;
+    mode: 'orbit' | 'anim' | 'fly' | 'walk';
+};
+
+const captureCameraState = (cm: CameraManager, state: State): CameraStateSnapshot => ({
+    position: [cm.camera.position.x, cm.camera.position.y, cm.camera.position.z],
+    angles: [cm.camera.angles.x, cm.camera.angles.y, cm.camera.angles.z],
+    distance: cm.camera.distance,
+    fov: cm.camera.fov,
+    mode: state.cameraMode
+});
+
+const restoreCameraState = (cm: CameraManager, state: State, snapshot: CameraStateSnapshot) => {
+    cm.camera.position.set(snapshot.position[0], snapshot.position[1], snapshot.position[2]);
+    cm.camera.angles.set(snapshot.angles[0], snapshot.angles[1], snapshot.angles[2]);
+    cm.camera.distance = snapshot.distance;
+    cm.camera.fov = snapshot.fov;
+    // Mode change (if any) fires cameraMode:changed which runs the new
+    // controller's onEnter against our just-set pose; snap() then cancels
+    // the resulting transition lerp. Same-mode case: snap() re-seeds the
+    // active controller in place.
+    if (state.cameraMode !== snapshot.mode) {
+        state.cameraMode = snapshot.mode;
+    }
+    cm.snap();
+};
+
+export { captureCameraState, restoreCameraState };
+export type { CameraStateSnapshot };

--- a/src/debug/debug-panel.ts
+++ b/src/debug/debug-panel.ts
@@ -1,6 +1,8 @@
-import { Vec3, type AppBase } from 'playcanvas';
+import { Vec3 } from 'playcanvas';
 
-import type { CameraManager, CameraStateSnapshot } from '../camera-manager';
+import type { CameraManager } from '../camera-manager';
+import type { Global } from '../types';
+import { captureCameraState, restoreCameraState, type CameraStateSnapshot } from './camera-state';
 
 // Developer / debug panel. Hidden by default; surfaced via `?debug` URL
 // param or Ctrl+Shift+D keyboard shortcut. DOM and styles are injected
@@ -93,7 +95,7 @@ const parseVector = (text: string): [number, number, number] | null => {
 };
 
 class DebugPanel {
-    private readonly _app: AppBase;
+    private readonly _global: Global;
 
     private readonly _cameraManager: CameraManager;
 
@@ -125,11 +127,11 @@ class DebugPanel {
         }
     };
 
-    constructor(app: AppBase, cameraManager: CameraManager, autoShow: boolean) {
-        this._app = app;
+    constructor(global: Global, cameraManager: CameraManager) {
+        this._global = global;
         this._cameraManager = cameraManager;
         window.addEventListener('keydown', this._onKeyDown);
-        if (autoShow) {
+        if (global.config.debug) {
             this.show();
         }
     }
@@ -141,9 +143,9 @@ class DebugPanel {
             this._build();
         }
         this._root!.style.display = '';
-        this._app.on('prerender', this._onPrerender);
-        window.getCameraState = () => this._cameraManager.getCameraState();
-        window.setCameraState = snapshot => this._cameraManager.setCameraState(snapshot);
+        this._global.app.on('prerender', this._onPrerender);
+        window.getCameraState = () => captureCameraState(this._cameraManager, this._global.state);
+        window.setCameraState = snapshot => restoreCameraState(this._cameraManager, this._global.state, snapshot);
         this._render();
     }
 
@@ -153,7 +155,7 @@ class DebugPanel {
         if (this._root) {
             this._root.style.display = 'none';
         }
-        this._app.off('prerender', this._onPrerender);
+        this._global.app.off('prerender', this._onPrerender);
         delete window.getCameraState;
         delete window.setCameraState;
     }
@@ -260,20 +262,19 @@ class DebugPanel {
     }
 
     private _applyPosition(pos: [number, number, number]) {
-        const snap = this._cameraManager.getCameraState();
-        snap.position = pos;
-        this._cameraManager.setCameraState(snap);
+        this._cameraManager.camera.position.set(pos[0], pos[1], pos[2]);
+        this._cameraManager.snap();
     }
 
     private _applyFocus(focus: [number, number, number]) {
         // Keep camera position fixed; recompute angles + distance so the
         // camera looks at the new focus point. Camera.look() does the math
-        // in place; setCameraState then re-seeds the active controller.
+        // in place; snap() then re-seeds the active controller.
         const cam = this._cameraManager.camera;
         const from = this._focusTmp.copy(cam.position);
         const to = new Vec3(focus[0], focus[1], focus[2]);
         cam.look(from, to);
-        this._cameraManager.setCameraState(this._cameraManager.getCameraState());
+        this._cameraManager.snap();
     }
 
     private _render() {
@@ -291,7 +292,7 @@ class DebugPanel {
     }
 
     private async _copy() {
-        const snapshot = this._cameraManager.getCameraState();
+        const snapshot = captureCameraState(this._cameraManager, this._global.state);
         try {
             await navigator.clipboard.writeText(JSON.stringify(snapshot));
             this._flash(this._copyButton);
@@ -304,7 +305,7 @@ class DebugPanel {
         try {
             const text = await navigator.clipboard.readText();
             const snapshot = JSON.parse(text) as CameraStateSnapshot;
-            this._cameraManager.setCameraState(snapshot);
+            restoreCameraState(this._cameraManager, this._global.state, snapshot);
             this._flash(this._pasteButton);
         } catch (err) {
             console.warn('[debug-panel] paste failed', err);

--- a/src/debug/debug-panel.ts
+++ b/src/debug/debug-panel.ts
@@ -111,6 +111,8 @@ class DebugPanel {
 
     private _pasteButton: HTMLButtonElement | null = null;
 
+    private _screenshotButton: HTMLButtonElement | null = null;
+
     private _editing: HTMLSpanElement | null = null;
 
     private _editCanceled = false;
@@ -192,6 +194,9 @@ class DebugPanel {
                 <button data-id="copy">Copy</button>
                 <button data-id="paste">Paste</button>
             </div>
+            <div class="buttons">
+                <button data-id="screenshot">Download screenshot</button>
+            </div>
         `;
         document.body.appendChild(root);
 
@@ -200,9 +205,11 @@ class DebugPanel {
         this._focusValue = root.querySelector('[data-id="focus"]')!;
         this._copyButton = root.querySelector('[data-id="copy"]')!;
         this._pasteButton = root.querySelector('[data-id="paste"]')!;
+        this._screenshotButton = root.querySelector('[data-id="screenshot"]')!;
 
         this._copyButton.addEventListener('click', () => this._copy());
         this._pasteButton.addEventListener('click', () => this._paste());
+        this._screenshotButton.addEventListener('click', () => this._screenshot());
         this._wireEditable(this._positionValue, 'position');
         this._wireEditable(this._focusValue, 'focus');
     }
@@ -310,6 +317,35 @@ class DebugPanel {
         } catch (err) {
             console.warn('[debug-panel] paste failed', err);
         }
+    }
+
+    private _screenshot() {
+        const app = this._global.app;
+        const canvas = app.graphicsDevice.canvas as HTMLCanvasElement;
+
+        // PlayCanvas runs with preserveDrawingBuffer off, so the canvas
+        // pixels are only readable in the same task as the render. Force
+        // a render and capture in frameend.
+        app.renderNextFrame = true;
+        app.once('frameend', () => {
+            // Quality 1.0 with image/webp produces lossless WebP in
+            // Chromium / Firefox. Safari (which lacks WebP encode) falls
+            // back to PNG automatically — blob.type tells us which.
+            canvas.toBlob((blob) => {
+                if (!blob) {
+                    console.warn('[debug-panel] screenshot toBlob returned null');
+                    return;
+                }
+                const ext = blob.type === 'image/webp' ? 'webp' : 'png';
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `supersplat-viewer.${ext}`;
+                a.click();
+                URL.revokeObjectURL(url);
+                this._flash(this._screenshotButton);
+            }, 'image/webp', 1.0);
+        });
     }
 
     private _flash(el: HTMLElement | null) {

--- a/src/debug/debug-panel.ts
+++ b/src/debug/debug-panel.ts
@@ -1,0 +1,331 @@
+import { Vec3, type AppBase } from 'playcanvas';
+
+import type { CameraManager, CameraStateSnapshot } from '../camera-manager';
+
+// Developer / debug panel. Hidden by default; surfaced via `?debug` URL
+// param or Ctrl+Shift+D keyboard shortcut. DOM and styles are injected
+// lazily on first show so there's no footprint on production URLs.
+
+const STYLE_ID = 'sse-debug-panel-style';
+const PANEL_ID = 'sse-debug-panel';
+
+const STYLES = `
+#${PANEL_ID} {
+    position: fixed;
+    top: max(8px, env(safe-area-inset-top));
+    left: max(8px, env(safe-area-inset-left));
+    padding: 8px 10px;
+    background: rgba(0, 0, 0, 0.7);
+    color: #eee;
+    font: 11px/1.4 ui-monospace, Menlo, Consolas, monospace;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    z-index: 1000;
+    pointer-events: auto;
+    user-select: none;
+    min-width: 220px;
+}
+#${PANEL_ID} .row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    white-space: nowrap;
+}
+#${PANEL_ID} .row .label {
+    color: #888;
+}
+#${PANEL_ID} .row .value {
+    color: #eee;
+    font-variant-numeric: tabular-nums;
+    cursor: text;
+    padding: 0 4px;
+    margin: 0 -4px;
+    border-radius: 2px;
+    transition: background-color 0.15s ease;
+    outline: none;
+}
+#${PANEL_ID} .row .value:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+#${PANEL_ID} .row .value:focus {
+    background: rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(120, 180, 255, 0.45);
+}
+#${PANEL_ID} .row .value.flash-ok {
+    background: rgba(120, 220, 140, 0.35);
+}
+#${PANEL_ID} .row .value.flash-bad {
+    background: rgba(220, 100, 100, 0.45);
+}
+#${PANEL_ID} .buttons {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+}
+#${PANEL_ID} button {
+    flex: 1;
+    background: rgba(255, 255, 255, 0.08);
+    color: #eee;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 3px;
+    padding: 4px 8px;
+    font: inherit;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+#${PANEL_ID} button:hover {
+    background: rgba(255, 255, 255, 0.16);
+}
+#${PANEL_ID} button.flash {
+    background: rgba(120, 220, 140, 0.35);
+}
+`;
+
+const fmt = (v: Vec3) => `${v.x.toFixed(3)}, ${v.y.toFixed(3)}, ${v.z.toFixed(3)}`;
+
+// Accepts "1,2,3", "1, 2, 3", "1 2 3", with or without trailing whitespace.
+const parseVector = (text: string): [number, number, number] | null => {
+    const parts = text.trim().split(/[\s,]+/).filter(p => p.length > 0);
+    if (parts.length !== 3) return null;
+    const nums = parts.map(Number);
+    if (nums.some(n => !Number.isFinite(n))) return null;
+    return [nums[0], nums[1], nums[2]];
+};
+
+class DebugPanel {
+    private readonly _app: AppBase;
+
+    private readonly _cameraManager: CameraManager;
+
+    private readonly _focusTmp = new Vec3();
+
+    private _root: HTMLDivElement | null = null;
+
+    private _positionValue: HTMLSpanElement | null = null;
+
+    private _focusValue: HTMLSpanElement | null = null;
+
+    private _copyButton: HTMLButtonElement | null = null;
+
+    private _pasteButton: HTMLButtonElement | null = null;
+
+    private _editing: HTMLSpanElement | null = null;
+
+    private _editCanceled = false;
+
+    private _visible = false;
+
+    private _onPrerender = () => this._render();
+
+    private _onKeyDown = (event: KeyboardEvent) => {
+        // Ctrl+Shift+D — also accept Meta+Shift+D on macOS for parity
+        if (event.code === 'KeyD' && event.shiftKey && (event.ctrlKey || event.metaKey)) {
+            event.preventDefault();
+            this.toggle();
+        }
+    };
+
+    constructor(app: AppBase, cameraManager: CameraManager, autoShow: boolean) {
+        this._app = app;
+        this._cameraManager = cameraManager;
+        window.addEventListener('keydown', this._onKeyDown);
+        if (autoShow) {
+            this.show();
+        }
+    }
+
+    show() {
+        if (this._visible) return;
+        this._visible = true;
+        if (!this._root) {
+            this._build();
+        }
+        this._root!.style.display = '';
+        this._app.on('prerender', this._onPrerender);
+        window.getCameraState = () => this._cameraManager.getCameraState();
+        window.setCameraState = snapshot => this._cameraManager.setCameraState(snapshot);
+        this._render();
+    }
+
+    hide() {
+        if (!this._visible) return;
+        this._visible = false;
+        if (this._root) {
+            this._root.style.display = 'none';
+        }
+        this._app.off('prerender', this._onPrerender);
+        delete window.getCameraState;
+        delete window.setCameraState;
+    }
+
+    toggle() {
+        if (this._visible) this.hide();
+        else this.show();
+    }
+
+    destroy() {
+        this.hide();
+        window.removeEventListener('keydown', this._onKeyDown);
+        if (this._root) {
+            this._root.remove();
+            this._root = null;
+        }
+        document.getElementById(STYLE_ID)?.remove();
+    }
+
+    private _build() {
+        if (!document.getElementById(STYLE_ID)) {
+            const style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.textContent = STYLES;
+            document.head.appendChild(style);
+        }
+
+        const root = document.createElement('div');
+        root.id = PANEL_ID;
+        root.innerHTML = `
+            <div class="row"><span class="label">camera</span><span class="value" data-id="position" contenteditable="plaintext-only" spellcheck="false" title="Edit to set camera position">—</span></div>
+            <div class="row"><span class="label">focus</span><span class="value" data-id="focus" contenteditable="plaintext-only" spellcheck="false" title="Edit to look at this point">—</span></div>
+            <div class="buttons">
+                <button data-id="copy">Copy</button>
+                <button data-id="paste">Paste</button>
+            </div>
+        `;
+        document.body.appendChild(root);
+
+        this._root = root;
+        this._positionValue = root.querySelector('[data-id="position"]')!;
+        this._focusValue = root.querySelector('[data-id="focus"]')!;
+        this._copyButton = root.querySelector('[data-id="copy"]')!;
+        this._pasteButton = root.querySelector('[data-id="paste"]')!;
+
+        this._copyButton.addEventListener('click', () => this._copy());
+        this._pasteButton.addEventListener('click', () => this._paste());
+        this._wireEditable(this._positionValue, 'position');
+        this._wireEditable(this._focusValue, 'focus');
+    }
+
+    private _wireEditable(span: HTMLSpanElement, kind: 'position' | 'focus') {
+        span.addEventListener('focus', () => {
+            this._editing = span;
+            this._editCanceled = false;
+            // select all text so the user can start typing to replace
+            const range = document.createRange();
+            range.selectNodeContents(span);
+            const sel = window.getSelection();
+            sel?.removeAllRanges();
+            sel?.addRange(range);
+        });
+        // Stop key events from bubbling to the canvas / window listeners
+        // (PlayCanvas KeyboardMouseSource and the wheel/key interrupt
+        // listeners) so arrow keys, WASD, etc. behave as text editing
+        // instead of moving the camera.
+        const stopKey = (e: KeyboardEvent) => e.stopPropagation();
+        span.addEventListener('keydown', (e) => {
+            stopKey(e);
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                span.blur();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                this._editCanceled = true;
+                span.blur();
+            }
+        });
+        span.addEventListener('keyup', stopKey);
+        span.addEventListener('keypress', stopKey);
+        span.addEventListener('blur', () => {
+            const wasCanceled = this._editCanceled;
+            this._editing = null;
+            this._editCanceled = false;
+            // clear any leftover selection
+            window.getSelection()?.removeAllRanges();
+            if (wasCanceled) {
+                this._render();
+                return;
+            }
+            const parsed = parseVector(span.textContent ?? '');
+            if (!parsed) {
+                this._flashBad(span);
+                this._render();
+                return;
+            }
+            if (kind === 'position') {
+                this._applyPosition(parsed);
+            } else {
+                this._applyFocus(parsed);
+            }
+            this._flashOk(span);
+        });
+    }
+
+    private _applyPosition(pos: [number, number, number]) {
+        const snap = this._cameraManager.getCameraState();
+        snap.position = pos;
+        this._cameraManager.setCameraState(snap);
+    }
+
+    private _applyFocus(focus: [number, number, number]) {
+        // Keep camera position fixed; recompute angles + distance so the
+        // camera looks at the new focus point. Camera.look() does the math
+        // in place; setCameraState then re-seeds the active controller.
+        const cam = this._cameraManager.camera;
+        const from = this._focusTmp.copy(cam.position);
+        const to = new Vec3(focus[0], focus[1], focus[2]);
+        cam.look(from, to);
+        this._cameraManager.setCameraState(this._cameraManager.getCameraState());
+    }
+
+    private _render() {
+        if (!this._visible || !this._positionValue || !this._focusValue) return;
+        const cam = this._cameraManager.camera;
+        cam.calcFocusPoint(this._focusTmp);
+        // Skip the span currently being edited so user input isn't
+        // overwritten by the per-frame refresh.
+        if (this._editing !== this._positionValue) {
+            this._positionValue.textContent = fmt(cam.position);
+        }
+        if (this._editing !== this._focusValue) {
+            this._focusValue.textContent = fmt(this._focusTmp);
+        }
+    }
+
+    private async _copy() {
+        const snapshot = this._cameraManager.getCameraState();
+        try {
+            await navigator.clipboard.writeText(JSON.stringify(snapshot));
+            this._flash(this._copyButton);
+        } catch (err) {
+            console.warn('[debug-panel] copy failed', err);
+        }
+    }
+
+    private async _paste() {
+        try {
+            const text = await navigator.clipboard.readText();
+            const snapshot = JSON.parse(text) as CameraStateSnapshot;
+            this._cameraManager.setCameraState(snapshot);
+            this._flash(this._pasteButton);
+        } catch (err) {
+            console.warn('[debug-panel] paste failed', err);
+        }
+    }
+
+    private _flash(el: HTMLElement | null) {
+        if (!el) return;
+        el.classList.add('flash');
+        setTimeout(() => el.classList.remove('flash'), 250);
+    }
+
+    private _flashOk(el: HTMLElement) {
+        el.classList.add('flash-ok');
+        setTimeout(() => el.classList.remove('flash-ok'), 250);
+    }
+
+    private _flashBad(el: HTMLElement) {
+        el.classList.add('flash-bad');
+        setTimeout(() => el.classList.remove('flash-bad'), 400);
+    }
+}
+
+export { DebugPanel };

--- a/src/debug/debug-panel.ts
+++ b/src/debug/debug-panel.ts
@@ -195,7 +195,7 @@ class DebugPanel {
                 <button data-id="paste">Paste</button>
             </div>
             <div class="buttons">
-                <button data-id="screenshot">Download screenshot</button>
+                <button data-id="screenshot">Screenshot</button>
             </div>
         `;
         document.body.appendChild(root);

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,1 @@
+export { DebugPanel } from './debug-panel';

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,1 +1,3 @@
 export { DebugPanel } from './debug-panel';
+export { captureCameraState, restoreCameraState } from './camera-state';
+export type { CameraStateSnapshot } from './camera-state';

--- a/src/index.html
+++ b/src/index.html
@@ -43,6 +43,7 @@
                 budget,
                 heatmap: url.searchParams.has('heatmap'),
                 fullload: url.searchParams.has('fullload'),
+                debug: url.searchParams.has('debug'),
             };
 
             window.sse = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ type Config = {
     budget?: number;                            // override splat budget in millions (overrides platform + performanceMode table)
     renderer: 'webgl' | 'webgpu';
     heatmap: boolean;                           // render heatmap debug overlay (WebGPU only)
+    debug: boolean;                             // auto-open the developer debug panel; can also be toggled with Ctrl+Shift+D
 };
 
 // observable state that can change at runtime

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -335,6 +335,12 @@ class Viewer {
             };
 
             window.animationDuration = state.animationDuration;
+
+            // Camera state get/set — useful from devtools for capturing a
+            // pose during debugging (`copy(getCameraState())`) and
+            // restoring it later via `setCameraState({...})`.
+            window.getCameraState = () => this.cameraManager.getCameraState();
+            window.setCameraState = snapshot => this.cameraManager.setCameraState(snapshot);
         });
 
         // wait for the model to load

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -394,7 +394,7 @@ class Viewer {
                 this.navCursor = new NavCursor(app, camera, collision ?? null, events, state);
             }
 
-            this.debugPanel = new DebugPanel(app, this.cameraManager, config.debug);
+            this.debugPanel = new DebugPanel(global, this.cameraManager);
 
             const { instance } = gsplat;
             if (instance) {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -34,6 +34,7 @@ import { Camera } from './cameras/camera';
 import type { Collision } from './collision';
 import { MeshCollision, VoxelCollision } from './collision';
 import { nearlyEquals } from './core/math';
+import { DebugPanel } from './debug';
 import { InputController } from './input-controller';
 import { MeshDebugOverlay } from './mesh-debug-overlay';
 import { NavCursor } from './nav-cursor';
@@ -162,6 +163,8 @@ class Viewer {
     meshOverlay: MeshDebugOverlay | null = null;
 
     navCursor: NavCursor | null = null;
+
+    debugPanel: DebugPanel | null = null;
 
     origChunks: {
         glsl: {
@@ -335,12 +338,6 @@ class Viewer {
             };
 
             window.animationDuration = state.animationDuration;
-
-            // Camera state get/set — useful from devtools for capturing a
-            // pose during debugging (`copy(getCameraState())`) and
-            // restoring it later via `setCameraState({...})`.
-            window.getCameraState = () => this.cameraManager.getCameraState();
-            window.setCameraState = snapshot => this.cameraManager.setCameraState(snapshot);
         });
 
         // wait for the model to load
@@ -396,6 +393,8 @@ class Viewer {
             if (!config.noui) {
                 this.navCursor = new NavCursor(app, camera, collision ?? null, events, state);
             }
+
+            this.debugPanel = new DebugPanel(app, this.cameraManager, config.debug);
 
             const { instance } = gsplat;
             if (instance) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -13,6 +13,22 @@ interface Window {
     scrubTo?: (time: number) => Promise<void>;
 
     animationDuration?: number;
+
+    getCameraState?: () => {
+        position: [number, number, number];
+        angles: [number, number, number];
+        distance: number;
+        fov: number;
+        mode: 'orbit' | 'anim' | 'fly' | 'walk';
+    };
+
+    setCameraState?: (snapshot: {
+        position: [number, number, number];
+        angles: [number, number, number];
+        distance: number;
+        fov: number;
+        mode: 'orbit' | 'anim' | 'fly' | 'walk';
+    }) => void;
 }
 
 declare module 'playcanvas/scripts/esm/xr-controllers.mjs' {


### PR DESCRIPTION
## Summary
Adds a developer-facing debug panel hidden from end users. Opt-in via `?debug` URL parameter or `Ctrl+Shift+D` (or `Cmd+Shift+D`) keyboard shortcut. The panel lives in a self-contained `src/debug/` module and injects its DOM + styles only when shown, so there's zero footprint on production URLs.

## Initial feature set
- **Live camera position** — current `cameraManager.camera.position`, updated per frame.
- **Live focus position** — `Camera.calcFocusPoint()`, updated per frame.
- **Editable vectors** — click either value to edit; Enter / blur applies, Esc cancels. Accepts `x,y,z`, `x, y, z`, or `x y z`. Camera-position edit moves the camera in place; focus-position edit rotates the camera to look at the new focus while preserving position. Invalid input flashes red and reverts.
- **Copy / Paste** — full camera-state snapshot (position, angles, distance, fov, mode) round-tripped through the system clipboard as JSON. Paste re-seeds the active controller (or switches modes) and snaps without a transition lerp.
- **Screenshot** — downloads the current frame as lossless WebP (`supersplat-viewer.webp`), falls back to PNG automatically on Safari. Forces a render and captures on `frameend` so the canvas buffer is readable.

## Architecture
- `src/debug/debug-panel.ts` — UI: DOM construction, styling, visibility, keyboard shortcut, copy / paste / screenshot / edit handlers. Stops keyboard event propagation while editing so arrow / WASD keys don't drive the camera.
- `src/debug/camera-state.ts` — `CameraStateSnapshot` type plus `captureCameraState` / `restoreCameraState` helpers.
- `src/camera-manager.ts` — exposes a single new primitive `snap()` that re-seeds the active controller from the current pose and cancels any in-flight transition. The previous `getCameraState` / `setCameraState` methods moved into the debug module since they were debug-only consumers.
- `src/index.html` — parses `?debug` into `sseConfig.debug`.
- `src/types.ts` — adds `debug: boolean` to `Config`.
- `types.d.ts` — declares optional `window.getCameraState` / `window.setCameraState`, attached when the panel is visible and removed on hide.

## Behaviour
- Plain URL → panel hidden, no DOM, `window.getCameraState` is `undefined`.
- `?debug` URL → panel auto-shows top-left.
- `Ctrl+Shift+D` toggles the panel on any URL.

## Test plan
- [ ] Plain URL: nothing visible; `document.getElementById('sse-debug-panel')` returns null.
- [ ] `?debug` URL: panel appears top-left, camera + focus update live as you move the camera.
- [ ] Ctrl+Shift+D / Cmd+Shift+D toggles visibility on any URL.
- [ ] Click camera value, type new vector, Enter — camera moves to that position. Try invalid input — red flash, reverts.
- [ ] Click focus value, type new vector — camera rotates to look at that point.
- [ ] Esc cancels an edit.
- [ ] Copy / Paste round-trip a snapshot, including across mode changes (capture in orbit, switch to fly, paste — restores orbit pose + mode).
- [ ] Screenshot on Chromium / Firefox produces a lossless WebP; Safari falls back to PNG. Filename is `supersplat-viewer.<webp|png>`.
- [ ] Arrow keys / WASD inside an editable field do NOT drive the camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)