### PR TITLE
Smooth fly and walk rotation, unify controller damping

### DIFF
--- a/src/cameras/anim-controller.ts
+++ b/src/cameras/anim-controller.ts
@@ -1,5 +1,6 @@
 import type { Camera, CameraFrame } from './camera';
 import { CameraController } from './camera';
+import { drainInputFrame } from './camera-utils';
 import { AnimState } from '../animation/anim-state';
 import { AnimTrack } from '../settings';
 
@@ -22,7 +23,7 @@ class AnimController implements CameraController {
         camera.look(this.animState.position, this.animState.target);
         camera.fov = this.animState.fov;
 
-        inputFrame.read();
+        drainInputFrame(inputFrame);
     }
 
     onExit(camera: Camera): void {

--- a/src/cameras/camera-utils.ts
+++ b/src/cameras/camera-utils.ts
@@ -1,7 +1,7 @@
 import { math, Quat, Vec3 } from 'playcanvas';
 
 import type { CameraFrame } from './camera';
-import { damp } from '../core/math';
+import { damp, mod } from '../core/math';
 
 /**
  * Shared damping factor for controller smoothing (rotate / move / zoom) so
@@ -114,7 +114,7 @@ const setBasisOffset = (
  *
  * @param angles - Current angles, mutated toward target.
  * @param target - Target angles.
- * @param damping - Damping factor in [0,1). Higher = smoother.
+ * @param damping - Damping factor in [0, 1]. Higher = smoother (1 = never moves).
  * @param dt - Delta time in seconds.
  * @returns The mutated angles.
  */
@@ -124,8 +124,8 @@ const dampAngles = (angles: Vec3, target: Vec3, damping: number, dt: number) => 
     }
     const t = damp(damping, dt);
     angles.x = math.lerpAngle(angles.x, target.x, t);
-    angles.y = math.lerpAngle(angles.y, target.y, t) % 360;
-    angles.z = math.lerpAngle(angles.z, target.z, t) % 360;
+    angles.y = mod(math.lerpAngle(angles.y, target.y, t), 360);
+    angles.z = mod(math.lerpAngle(angles.z, target.z, t), 360);
     return angles;
 };
 

--- a/src/cameras/camera-utils.ts
+++ b/src/cameras/camera-utils.ts
@@ -1,6 +1,16 @@
 import { math, Quat, Vec3 } from 'playcanvas';
 
+import type { CameraFrame } from './camera';
 import { damp } from '../core/math';
+
+/**
+ * Shared damping factor for controller smoothing (rotate / move / zoom) so
+ * orbit, fly, and walk feel the same. Used as `damp(damping, dt)` →
+ * `1 - damping^(dt*1000)`. Higher means smoother / more lag. Not used for
+ * physics-style velocity decay (e.g. walk's grounded/air velocity damping),
+ * which has different tuning needs.
+ */
+const DEFAULT_CONTROLLER_DAMPING = 0.97;
 
 const rotation = new Quat();
 
@@ -119,9 +129,23 @@ const dampAngles = (angles: Vec3, target: Vec3, damping: number, dt: number) => 
     return angles;
 };
 
+/**
+ * Discard any pending input deltas in the frame. `InputFrame.read()` zeros
+ * deltas as a side-effect of reading, so calling this prevents accumulated
+ * input from leaking into the next controller when a non-input-driven mode
+ * (e.g. animation) is active.
+ *
+ * @param frame - The camera frame whose deltas should be drained.
+ */
+const drainInputFrame = (frame: CameraFrame) => {
+    frame.read();
+};
+
 export {
+    DEFAULT_CONTROLLER_DAMPING,
     applyFrameRotation,
     dampAngles,
+    drainInputFrame,
     setBasisOffset,
     setCameraBasis,
     setCameraForward,

--- a/src/cameras/camera-utils.ts
+++ b/src/cameras/camera-utils.ts
@@ -1,5 +1,7 @@
 import { math, Quat, Vec3 } from 'playcanvas';
 
+import { damp } from '../core/math';
+
 const rotation = new Quat();
 
 /**
@@ -95,8 +97,31 @@ const setBasisOffset = (
     return out;
 };
 
+/**
+ * Lerp Euler angles toward a target using frame-rate-independent shortest-path
+ * interpolation. Yaw/roll are wrapped to keep magnitudes bounded across long
+ * sessions; pitch is left untouched since callers clamp it.
+ *
+ * @param angles - Current angles, mutated toward target.
+ * @param target - Target angles.
+ * @param damping - Damping factor in [0,1). Higher = smoother.
+ * @param dt - Delta time in seconds.
+ * @returns The mutated angles.
+ */
+const dampAngles = (angles: Vec3, target: Vec3, damping: number, dt: number) => {
+    if (dt <= 0) {
+        return angles;
+    }
+    const t = damp(damping, dt);
+    angles.x = math.lerpAngle(angles.x, target.x, t);
+    angles.y = math.lerpAngle(angles.y, target.y, t) % 360;
+    angles.z = math.lerpAngle(angles.z, target.z, t) % 360;
+    return angles;
+};
+
 export {
     applyFrameRotation,
+    dampAngles,
     setBasisOffset,
     setCameraBasis,
     setCameraForward,

--- a/src/cameras/fly-controller.ts
+++ b/src/cameras/fly-controller.ts
@@ -2,7 +2,7 @@ import { Vec3 } from 'playcanvas';
 
 import type { Collision } from '../collision';
 import type { CameraFrame, Camera, CameraController } from './camera';
-import { applyFrameRotation, setBasisOffset, setCameraBasis } from './camera-utils';
+import { applyFrameRotation, dampAngles, setBasisOffset, setCameraBasis } from './camera-utils';
 import { SphereMover } from './sphere-mover';
 
 /** Radius of the camera collision sphere (meters) */
@@ -16,9 +16,13 @@ const offset = new Vec3();
 class FlyController implements CameraController {
     fov = 90;
 
+    rotateDamping = 0.97;
+
     private _position = new Vec3();
 
     private _angles = new Vec3();
+
+    private _targetAngles = new Vec3();
 
     private _distance = 1;
 
@@ -51,7 +55,8 @@ class FlyController implements CameraController {
     update(deltaTime: number, inputFrame: CameraFrame, camera: Camera) {
         const { move, rotate } = inputFrame.read();
 
-        applyFrameRotation(this._angles, rotate);
+        applyFrameRotation(this._targetAngles, rotate);
+        dampAngles(this._angles, this._targetAngles, this.rotateDamping, deltaTime);
 
         this._step(move);
 
@@ -68,6 +73,7 @@ class FlyController implements CameraController {
     goto(camera: Camera) {
         this._position.copy(camera.position);
         this._angles.set(camera.angles.x, camera.angles.y, 0);
+        this._targetAngles.copy(this._angles);
         this._distance = camera.distance;
         this._mover.reset(this._position);
     }
@@ -79,6 +85,7 @@ class FlyController implements CameraController {
 
         this._position.copy(this._spawnPosition);
         this._angles.copy(this._spawnAngles);
+        this._targetAngles.copy(this._spawnAngles);
         this._distance = this._spawnDistance;
         this._mover.reset(this._position);
 

--- a/src/cameras/fly-controller.ts
+++ b/src/cameras/fly-controller.ts
@@ -2,7 +2,7 @@ import { Vec3 } from 'playcanvas';
 
 import type { Collision } from '../collision';
 import type { CameraFrame, Camera, CameraController } from './camera';
-import { applyFrameRotation, dampAngles, setBasisOffset, setCameraBasis } from './camera-utils';
+import { DEFAULT_CONTROLLER_DAMPING, applyFrameRotation, dampAngles, setBasisOffset, setCameraBasis } from './camera-utils';
 import { SphereMover } from './sphere-mover';
 
 /** Radius of the camera collision sphere (meters) */
@@ -16,7 +16,7 @@ const offset = new Vec3();
 class FlyController implements CameraController {
     fov = 90;
 
-    rotateDamping = 0.97;
+    rotateDamping = DEFAULT_CONTROLLER_DAMPING;
 
     private _position = new Vec3();
 

--- a/src/cameras/orbit-controller.ts
+++ b/src/cameras/orbit-controller.ts
@@ -5,6 +5,7 @@ import {
 } from 'playcanvas';
 
 import type { Camera, CameraFrame, CameraController } from './camera';
+import { DEFAULT_CONTROLLER_DAMPING } from './camera-utils';
 
 const p = new Pose();
 
@@ -17,9 +18,9 @@ class OrbitController implements CameraController {
         this.controller = new OrbitControllerPC();
         this.controller.zoomRange = new Vec2(0.01, Infinity);
         this.controller.pitchRange = new Vec2(-90, 90);
-        this.controller.rotateDamping = 0.97;
-        this.controller.moveDamping = 0.97;
-        this.controller.zoomDamping = 0.97;
+        this.controller.rotateDamping = DEFAULT_CONTROLLER_DAMPING;
+        this.controller.moveDamping = DEFAULT_CONTROLLER_DAMPING;
+        this.controller.zoomDamping = DEFAULT_CONTROLLER_DAMPING;
     }
 
     onEnter(camera: Camera): void {

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -2,7 +2,7 @@ import { math, Vec3 } from 'playcanvas';
 
 import type { Collision, PushOut } from '../collision';
 import type { CameraFrame, Camera, CameraController } from './camera';
-import { applyFrameRotation, dampAngles, setBasisOffset, setYawBasis } from './camera-utils';
+import { DEFAULT_CONTROLLER_DAMPING, applyFrameRotation, dampAngles, setBasisOffset, setYawBasis } from './camera-utils';
 import { findWalkSpawn } from './walk-spawn';
 import { damp } from '../core/math';
 
@@ -77,14 +77,9 @@ class WalkController implements CameraController {
     moveAirSpeed = 1;
 
     /**
-     * Movement damping factor (0 = no damping, 1 = full damping)
-     */
-    moveDamping = 0.97;
-
-    /**
      * Rotation damping factor (0 = no damping, 1 = full damping)
      */
-    rotateDamping = 0.97;
+    rotateDamping = DEFAULT_CONTROLLER_DAMPING;
 
     /**
      * Velocity damping factor when grounded (0 = no damping, 1 = full damping)

--- a/src/cameras/walk-controller.ts
+++ b/src/cameras/walk-controller.ts
@@ -2,7 +2,7 @@ import { math, Vec3 } from 'playcanvas';
 
 import type { Collision, PushOut } from '../collision';
 import type { CameraFrame, Camera, CameraController } from './camera';
-import { applyFrameRotation, setBasisOffset, setYawBasis } from './camera-utils';
+import { applyFrameRotation, dampAngles, setBasisOffset, setYawBasis } from './camera-utils';
 import { findWalkSpawn } from './walk-spawn';
 import { damp } from '../core/math';
 
@@ -129,6 +129,8 @@ class WalkController implements CameraController {
 
     private _angles = new Vec3();
 
+    private _targetAngles = new Vec3();
+
     private _distance = 1;
 
     private _spawnPosition = new Vec3();
@@ -172,7 +174,8 @@ class WalkController implements CameraController {
         const { move, rotate } = inputFrame.read();
 
         // apply rotation at display rate for responsive mouse look
-        applyFrameRotation(this._angles, rotate);
+        applyFrameRotation(this._targetAngles, rotate);
+        dampAngles(this._angles, this._targetAngles, this.rotateDamping, deltaTime);
 
         // accumulate movement input so frames without a physics step don't lose input
         this._pendingMove[0] += move[0];
@@ -280,6 +283,7 @@ class WalkController implements CameraController {
 
         // angles (clamp pitch to avoid gimbal lock)
         this._angles.set(camera.angles.x, camera.angles.y, 0);
+        this._targetAngles.copy(this._angles);
         this._distance = camera.distance;
 
         // reset velocity and state
@@ -300,6 +304,7 @@ class WalkController implements CameraController {
         this._position.copy(this._spawnPosition);
         this._prevPosition.copy(this._position);
         this._angles.copy(this._spawnAngles);
+        this._targetAngles.copy(this._spawnAngles);
         this._distance = this._spawnDistance;
         this._resetMotion();
         this._grounded = this._spawnGrounded;


### PR DESCRIPTION
## Summary
- Add frame-rate-independent rotation damping to fly and walk controllers via a new `_targetAngles` + `dampAngles()` flow, matching the orbit controller's feel.
- Extract the `0.97` damping factor into `DEFAULT_CONTROLLER_DAMPING` in `camera-utils` so orbit/fly/walk stay in sync.
- Drop the unused `moveDamping` field from `WalkController`.
- Replace the bare `inputFrame.read()` in the anim controller with a named `drainInputFrame()` helper so the intent (zeroing pending deltas) is explicit.

## Test plan
- [ ] Fly mode: look feels smoother; no perceptible lag on start/stop.
- [ ] Walk mode: smoother look, pitch still clamps at ±90°.
- [ ] Orbit mode: unchanged behavior.
- [ ] Switching into/out of animation playback: no input drift from accumulated deltas.