### PR TITLE
Fix camera spin glitch after multiple rotations

### DIFF
--- a/src/cameras/camera-utils.ts
+++ b/src/cameras/camera-utils.ts
@@ -10,7 +10,7 @@ import { damp, mod } from '../core/math';
  * physics-style velocity decay (e.g. walk's grounded/air velocity damping),
  * which has different tuning needs.
  */
-const DEFAULT_CONTROLLER_DAMPING = 0.97;
+const DEFAULT_CONTROLLER_DAMPING = 0.96;
 
 const rotation = new Quat();
 
@@ -109,11 +109,14 @@ const setBasisOffset = (
 
 /**
  * Lerp Euler angles toward a target using frame-rate-independent shortest-path
- * interpolation. Yaw/roll are wrapped to keep magnitudes bounded across long
- * sessions; pitch is left untouched since callers clamp it.
+ * interpolation. Yaw/roll on both `angles` and `target` are wrapped into
+ * `[0, 360)` so `lerpAngle`'s single-shift shortest-path stays valid after
+ * many full rotations (otherwise the camera takes the long way around). Pitch
+ * is left untouched since callers clamp it.
  *
  * @param angles - Current angles, mutated toward target.
- * @param target - Target angles.
+ * @param target - Target angles. Yaw/roll are wrapped in place to keep
+ * accumulated drift bounded across frames.
  * @param damping - Damping factor in [0, 1]. Higher = smoother (1 = never moves).
  * @param dt - Delta time in seconds.
  * @returns The mutated angles.
@@ -123,9 +126,13 @@ const dampAngles = (angles: Vec3, target: Vec3, damping: number, dt: number) => 
         return angles;
     }
     const t = damp(damping, dt);
+    angles.y = mod(angles.y, 360);
+    angles.z = mod(angles.z, 360);
+    target.y = mod(target.y, 360);
+    target.z = mod(target.z, 360);
     angles.x = math.lerpAngle(angles.x, target.x, t);
-    angles.y = mod(math.lerpAngle(angles.y, target.y, t), 360);
-    angles.z = mod(math.lerpAngle(angles.z, target.z, t), 360);
+    angles.y = math.lerpAngle(angles.y, target.y, t);
+    angles.z = math.lerpAngle(angles.z, target.z, t);
     return angles;
 };
 


### PR DESCRIPTION
## Summary
- Wrap both `angles` and `target` yaw/roll into `[0, 360)` before `lerpAngle`  in `dampAngles`. Previously only the current angles were wrapped, so  `_targetAngles.y` accumulated unboundedly — after one full spin the gap  exceeded `lerpAngle`'s single-shift shortest-path range and the camera  took the long way around (visible as a snap/spin).
- Mutate `target` in place so its accumulated drift stays bounded across frames.
- Nudge `DEFAULT_CONTROLLER_DAMPING` from 0.97 → 0.96 for a slightly snappier feel.

## Test plan
- [ ] Fly mode: spin yaw 3+ full rotations, confirm smooth tracking with no snaps.
- [ ] Walk mode: same.
- [ ] Orbit mode: unchanged behavior, slightly snappier damping.