### PR TITLE
Default to WebGPU; swap ?webgpu param for ?webgl; AR/VR prompt under WebGPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ The app supports a number of URL parameters (these are subject to change):
 
 ### Renderer
 
-By default the viewer uses WebGL. The flag below opts into WebGPU rendering:
+By default the viewer uses WebGPU when available (falling back automatically when not). The flag below forces the WebGL renderer (also required for WebXR / AR / VR):
 
 | Parameter | Description |
 | --------- | ----------- |
-| `webgpu` | Use the WebGPU hybrid renderer (raster + GPU radix sort) |
+| `webgl` | Force the WebGL renderer (required for AR/VR) |
 | `aa` | Enable antialiasing (WebGL only) |
 | `nofx` | Disable post effects |
 | `hpr` | Override `highPrecisionRendering` from settings (`?hpr`, `?hpr=1`, `?hpr=true`, `?hpr=enable` to enable) |

--- a/src/index.html
+++ b/src/index.html
@@ -492,7 +492,7 @@
             <div id="tooltip"></div>
 
             <!-- XR WebGL-required modal -->
-            <div id="xrModal" class="hidden">
+            <div id="xrModal" class="hidden" onwheel="event.stopPropagation()">
                 <div id="xrModalContent" onpointerdown="event.stopPropagation()">
                     <h2>WebGL Required</h2>
                     <p>AR and VR are not supported on the WebGPU renderer. Pressing OK will reload the viewer with WebGL.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
             const settingsUrl = url.searchParams.has('settings') ? url.searchParams.get('settings') : './settings.json';
             const contentUrl = url.searchParams.has('content') ? url.searchParams.get('content') : './scene.compressed.ply';
 
-            const renderer = url.searchParams.has('webgpu') ? 'webgpu' : 'webgl';
+            const renderer = url.searchParams.has('webgl') ? 'webgl' : 'webgpu';
 
             const budgetParam = url.searchParams.get('budget');
             const budget = budgetParam !== null ? Number(budgetParam) : undefined;
@@ -490,6 +490,18 @@
 
             <!-- Tooltip -->
             <div id="tooltip"></div>
+
+            <!-- XR WebGL-required modal -->
+            <div id="xrModal" class="hidden">
+                <div id="xrModalContent" onpointerdown="event.stopPropagation()">
+                    <h2>WebGL Required</h2>
+                    <p>AR and VR are not supported on the WebGPU renderer. Pressing OK will reload the viewer with WebGL.</p>
+                    <div id="xrModalButtons">
+                        <button id="xrModalCancel">Cancel</button>
+                        <button id="xrModalOk">OK</button>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- SVG Icons -->

--- a/src/index.scss
+++ b/src/index.scss
@@ -658,6 +658,80 @@ button {
     }
 }
 
+/* xr WebGL-required modal */
+
+#xrModal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(black, 0.4);
+    backdrop-filter: blur(2px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    > #xrModalContent {
+        width: min(360px, calc(100vw - 32px));
+        padding: 20px;
+        border-radius: 16px;
+        border: 1px solid rgba(white, 0.1);
+
+        color: $clr-text;
+        background-color: rgba($clr-bkg, 0.9);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+
+        > h2 {
+            font-size: 16px;
+            font-weight: bold;
+            color: $clr-text-light;
+            margin-bottom: 12px;
+        }
+
+        > p {
+            font-size: 13px;
+            line-height: 1.4;
+            color: $clr-text;
+            margin-bottom: 16px;
+        }
+
+        > #xrModalButtons {
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+
+            > button {
+                height: 34px;
+                padding: 0 20px;
+                border: 1px solid rgba(white, 0.1);
+                border-radius: 8px;
+                font-size: 13px;
+                cursor: pointer;
+                color: $clr-text-dark;
+                background-color: rgba(white, 0.04);
+                transition: background-color 250ms ease, color 250ms ease;
+
+                &:hover {
+                    color: $clr-text-light;
+                    background-color: rgba(white, 0.1);
+                }
+
+                &#xrModalOk {
+                    color: $clr-text-light;
+                    background-color: rgba($clr-accent, 0.7);
+                    border-color: rgba($clr-accent, 0.8);
+
+                    &:hover {
+                        background-color: $clr-accent;
+                    }
+                }
+            }
+        }
+    }
+}
+
 #tooltip {
     display: none;
     position: absolute;

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,11 +108,9 @@ const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
 
     console.log(`Renderer: ${device.deviceType}`);
 
-    // Reconcile config with the actual device — the engine may have fallen back
-    // from WebGPU to WebGL2, in which case downstream code (voxel overlay, XR,
-    // gsplat renderer selection) should treat this as the WebGL path.
-    // eslint-disable-next-line require-atomic-updates
-    config.renderer = device.deviceType === 'webgpu' ? 'webgpu' : 'webgl';
+    // The engine may have fallen back from WebGPU to WebGL2; downstream code
+    // (voxel overlay, XR, gsplat renderer selection) needs the *actual* renderer.
+    const renderer: 'webgl' | 'webgpu' = device.deviceType === 'webgpu' ? 'webgpu' : 'webgl';
 
     // Set maxPixelRatio so the XR framebuffer scale factor is computed correctly.
     // Regular rendering bypasses maxPixelRatio via the custom initCanvas sizing.
@@ -143,7 +141,7 @@ const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
 
     app.scene.ambientLight.set(0.51, 0.55, 0.65);
 
-    return { app, camera };
+    return { app, camera, renderer };
 };
 
 // initialize canvas size and resizing
@@ -204,7 +202,7 @@ const initCanvas = (global: Global) => {
 };
 
 const main = async (canvas: HTMLCanvasElement, settingsJson: any, config: Config) => {
-    const { app, camera } = await createApp(canvas, config);
+    const { app, camera, renderer } = await createApp(canvas, config);
 
     // create events
     const events = new EventHandler();
@@ -245,7 +243,8 @@ const main = async (canvas: HTMLCanvasElement, settingsJson: any, config: Config
         config,
         state,
         events,
-        camera
+        camera,
+        renderer
     };
 
     initCanvas(global);

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,17 +94,25 @@ const loadSkybox = (app: AppBase, url: string) => {
 const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
     const useWebGPU = config.renderer === 'webgpu';
 
-    // Create the graphics device
+    // Create the graphics device. The engine auto-appends WebGL2/null fallbacks
+    // when WebGPU isn't supported, so request xrCompatible so the WebGL fallback
+    // is also usable for AR/VR.
     const device = await createGraphicsDevice(canvas, {
         deviceTypes: useWebGPU ? ['webgpu'] : [],
         antialias: false,
         depth: true,
         stencil: false,
-        xrCompatible: !useWebGPU,
+        xrCompatible: true,
         powerPreference: 'high-performance'
     });
 
     console.log(`Renderer: ${device.deviceType}`);
+
+    // Reconcile config with the actual device — the engine may have fallen back
+    // from WebGPU to WebGL2, in which case downstream code (voxel overlay, XR,
+    // gsplat renderer selection) should treat this as the WebGL path.
+    // eslint-disable-next-line require-atomic-updates
+    config.renderer = device.deviceType === 'webgpu' ? 'webgpu' : 'webgl';
 
     // Set maxPixelRatio so the XR framebuffer scale factor is computed correctly.
     // Regular rendering bypasses maxPixelRatio via the custom initCanvas sizing.
@@ -252,10 +260,9 @@ const main = async (canvas: HTMLCanvasElement, settingsJson: any, config: Config
 
     camera.addComponent('camera');
 
-    // Initialize XR support
-    if (config.renderer === 'webgl') {
-        initXr(global);
-    }
+    // Initialize XR support (availability detection always runs so the UI can offer
+    // a reload into WebGL when the user requests AR/VR under WebGPU)
+    initXr(global);
 
     // Initialize user interface
     initUI(global);

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ type Config = {
     fullload: boolean;                          // load all streaming LOD data before first frame
     aa: boolean;                                // render with antialiasing
     budget?: number;                            // override splat budget in millions (overrides platform + performanceMode table)
-    renderer: 'webgl' | 'webgpu';
+    renderer: 'webgl' | 'webgpu';               // requested renderer; the actual one (after engine fallback) is exposed as Global.renderer
     heatmap: boolean;                           // render heatmap debug overlay (WebGPU only)
     debug: boolean;                             // auto-open the developer debug panel; can also be toggled with Ctrl+Shift+D
 };
@@ -58,6 +58,7 @@ type Global = {
     state: State;
     events: EventHandler;
     camera: Entity;
+    renderer: 'webgl' | 'webgpu';               // actual renderer in use (reflects engine fallback from WebGPU to WebGL2)
 };
 
 export { CameraMode, InputMode, Config, State, Global };

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -393,11 +393,13 @@ const initUI = (global: Global) => {
     const vrChanged = () => dom.vrMode.classList[state.hasVR ? 'remove' : 'add']('hidden');
 
     // XR sessions require a WebGL device. Under WebGPU, prompt the user to reload
-    // the viewer with the WebGL renderer before starting AR/VR.
+    // the viewer with the WebGL renderer before starting AR/VR. Use replace() so
+    // the renderer-switch reload doesn't add a back-button entry — important
+    // because the viewer often runs inside an iframe (e.g. superspl.at /scene).
     const reloadWithWebgl = () => {
         const reloadUrl = new URL(location.href);
         reloadUrl.searchParams.set('webgl', '');
-        location.href = reloadUrl.toString();
+        location.replace(reloadUrl.toString());
     };
 
     const showXrModal = () => dom.xrModal.classList.remove('hidden');

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -247,7 +247,8 @@ const initUI = (global: Global) => {
         'showCollision', 'desktopShowCollisionHelp',
         'tooltip',
         'annotationNav', 'annotationPrev', 'annotationNext', 'annotationInfo', 'annotationNavTitle',
-        'viewerBranding', 'viewerTitle', 'appVersionLabel'
+        'viewerBranding', 'viewerTitle', 'appVersionLabel',
+        'xrModal', 'xrModalOk', 'xrModalCancel'
     ].reduce((acc: Record<string, HTMLElement>, id) => {
         acc[id] = document.getElementById(id);
         return acc;
@@ -391,8 +392,31 @@ const initUI = (global: Global) => {
     const arChanged = () => dom.arMode.classList[state.hasAR ? 'remove' : 'add']('hidden');
     const vrChanged = () => dom.vrMode.classList[state.hasVR ? 'remove' : 'add']('hidden');
 
-    dom.arMode.addEventListener('click', () => events.fire('startAR'));
-    dom.vrMode.addEventListener('click', () => events.fire('startVR'));
+    // XR sessions require a WebGL device. Under WebGPU, prompt the user to reload
+    // the viewer with the WebGL renderer before starting AR/VR.
+    const reloadWithWebgl = () => {
+        const reloadUrl = new URL(location.href);
+        reloadUrl.searchParams.set('webgl', '');
+        location.href = reloadUrl.toString();
+    };
+
+    const showXrModal = () => dom.xrModal.classList.remove('hidden');
+    const hideXrModal = () => dom.xrModal.classList.add('hidden');
+
+    dom.xrModalOk.addEventListener('click', reloadWithWebgl);
+    dom.xrModalCancel.addEventListener('click', hideXrModal);
+    dom.xrModal.addEventListener('pointerdown', hideXrModal);
+
+    const handleXrClick = (type: 'AR' | 'VR') => {
+        if (config.renderer !== 'webgl') {
+            showXrModal();
+        } else {
+            events.fire(type === 'AR' ? 'startAR' : 'startVR');
+        }
+    };
+
+    dom.arMode.addEventListener('click', () => handleXrClick('AR'));
+    dom.vrMode.addEventListener('click', () => handleXrClick('VR'));
 
     events.on('hasAR:changed', arChanged);
     events.on('hasVR:changed', vrChanged);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -410,7 +410,7 @@ const initUI = (global: Global) => {
     dom.xrModal.addEventListener('pointerdown', hideXrModal);
 
     const handleXrClick = (type: 'AR' | 'VR') => {
-        if (config.renderer !== 'webgl') {
+        if (global.renderer !== 'webgl') {
             showXrModal();
         } else {
             events.fire(type === 'AR' ? 'startAR' : 'startVR');

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -180,7 +180,7 @@ class Viewer {
     constructor(global: Global, gsplatLoad: Promise<Entity>, skyboxLoad: Promise<void> | undefined, collisionLoad: Promise<Collision> | undefined) {
         this.global = global;
 
-        const { app, settings, config, events, state, camera } = global;
+        const { app, settings, config, events, state, camera, renderer } = global;
         const { graphicsDevice } = app;
 
         // enable anonymous CORS for image loading in safari
@@ -368,7 +368,7 @@ class Viewer {
 
             // Create collision debug overlay (voxel uses a compute shader, mesh
             // uses standard line rendering). The voxel path requires WebGPU.
-            if (collision instanceof VoxelCollision && config.renderer !== 'webgl') {
+            if (collision instanceof VoxelCollision && renderer !== 'webgl') {
                 this.voxelOverlay = new VoxelDebugOverlay(app, collision, camera);
                 this.voxelOverlay.mode = config.heatmap ? 'heatmap' : 'overlay';
                 state.hasCollisionOverlay = true;
@@ -508,7 +508,7 @@ class Viewer {
 
                         // debug colorize lods
                         gsplat.debug = config.colorize ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
-                        gsplat.renderer = rendererTable[config.renderer];
+                        gsplat.renderer = rendererTable[renderer];
 
                         // wait for the first valid frame to complete rendering
                         app.once('frameend', () => {

--- a/src/xr.ts
+++ b/src/xr.ts
@@ -12,7 +12,7 @@ import { Global } from './types';
 
 // On entering/exiting AR, we need to set the camera clear color to transparent black
 const initXr = (global: Global) => {
-    const { app, events, state, camera, config } = global;
+    const { app, events, state, camera, renderer } = global;
 
     state.hasAR = app.xr.isAvailable('immersive-ar');
     state.hasVR = app.xr.isAvailable('immersive-vr');
@@ -27,7 +27,7 @@ const initXr = (global: Global) => {
 
     // XR sessions require a WebGL device; under WebGPU we only expose availability so
     // the UI can offer to reload the viewer in WebGL mode.
-    if (config.renderer !== 'webgl') {
+    if (renderer !== 'webgl') {
         return;
     }
 

--- a/src/xr.ts
+++ b/src/xr.ts
@@ -12,7 +12,7 @@ import { Global } from './types';
 
 // On entering/exiting AR, we need to set the camera clear color to transparent black
 const initXr = (global: Global) => {
-    const { app, events, state, camera } = global;
+    const { app, events, state, camera, config } = global;
 
     state.hasAR = app.xr.isAvailable('immersive-ar');
     state.hasVR = app.xr.isAvailable('immersive-vr');
@@ -24,6 +24,12 @@ const initXr = (global: Global) => {
     app.xr.on('available:immersive-vr', (available) => {
         state.hasVR = available;
     });
+
+    // XR sessions require a WebGL device; under WebGPU we only expose availability so
+    // the UI can offer to reload the viewer in WebGL mode.
+    if (config.renderer !== 'webgl') {
+        return;
+    }
 
     const parent = camera.parent as Entity;
     const clearColor = new Color();


### PR DESCRIPTION
## Summary
- Viewer now defaults to WebGPU when the browser supports it (engine auto-falls back to WebGL2 otherwise). The opt-in `?webgpu` URL param is replaced with `?webgl`, which forces the WebGL renderer.
- After `createGraphicsDevice` returns, `config.renderer` is reconciled against `device.deviceType` so downstream code (gsplat renderer selection, voxel overlay, XR init) always matches the device that was actually created — fixes the silent case where a `?webgpu` request fell back to WebGL2 but the rest of the viewer still believed it was on WebGPU.
- AR/VR availability detection is now wired up in both renderer modes. Under WebGL the buttons start a session as before; under WebGPU they open a small modal explaining that AR/VR requires WebGL. OK calls `location.replace()` with `?webgl` appended so only the iframe reloads and no back-button entry is added on the parent page.
- `xrCompatible: true` is now always passed to `createGraphicsDevice` so the WebGL2 fallback path is usable for WebXR.

## Test plan
- [ ] Open the viewer with no params in a WebGPU-capable browser; confirm renderer is WebGPU and no `?webgl` is present.
- [ ] Open the viewer with `?webgl`; confirm renderer is WebGL2.
- [ ] In WebGPU mode, click AR or VR; confirm the modal appears. Click Cancel — modal closes, no reload. Click OK — iframe reloads with `?webgl`, AR/VR session starts.
- [ ] Verify the parent back button isn't polluted by the renderer-switch reload.
- [ ] Open a scene in Safari (no WebGPU); confirm engine falls back to WebGL2 and AR/VR works without the popup (reconciled `config.renderer`).
- [ ] Run the superspl.at scene-viewer-loads playwright suite; confirm the WebGL2-fallback path still passes.
- [ ] Verify the server's regex substitutions still apply to the built `public/index.html`.