### PR TITLE
Fix skybox CORS tainting and don't abort viewer when skybox fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
     platform,
     TouchDevice,
     type Texture,
+    type TextureHandler,
     type AppBase,
     revision as engineRevision,
     version as engineVersion
@@ -123,6 +124,11 @@ const createApp = async (canvas: HTMLCanvasElement, config: Config) => {
         touch: new TouchDevice(canvas),
         keyboard: new Keyboard(window)
     });
+
+    // enable anonymous CORS for image loading in safari (must be set before any
+    // texture asset starts loading, otherwise the <img> is fetched without the
+    // crossorigin attribute and WebGL rejects it with SecurityError)
+    (app.loader.getHandler('texture') as TextureHandler).imgParser.crossOrigin = 'anonymous';
 
     // Create entity hierarchy
     const cameraRoot = new Entity('camera root');
@@ -275,10 +281,12 @@ const main = async (canvas: HTMLCanvasElement, settingsJson: any, config: Config
         }
     );
 
-    // Load skybox
+    // Load skybox (continue without if it fails — e.g. CORS, 404)
     const skyboxLoad = config.skyboxUrl &&
         loadSkybox(app, config.skyboxUrl).then((asset) => {
             app.scene.envAtlas = asset.resource as Texture;
+        }).catch((err: Error) => {
+            console.warn('Failed to load skybox:', err);
         });
 
     // Load collision data (type determined by file extension)

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -9,7 +9,6 @@ import {
     Mat4,
     MiniStats,
     ShaderChunks,
-    type TextureHandler,
     PIXELFORMAT_RGBA16F,
     PIXELFORMAT_RGBA32F,
     TONEMAP_NONE,
@@ -182,9 +181,6 @@ class Viewer {
 
         const { app, settings, config, events, state, camera, renderer } = global;
         const { graphicsDevice } = app;
-
-        // enable anonymous CORS for image loading in safari
-        (app.loader.getHandler('texture') as TextureHandler).imgParser.crossOrigin = 'anonymous';
 
         // render skybox as plain equirect
         const glsl = ShaderChunks.get(graphicsDevice, 'glsl');


### PR DESCRIPTION
## Summary
- Move `imgParser.crossOrigin = 'anonymous'` from the `Viewer` constructor into `createApp`, right after the `App` is instantiated. The skybox load was kicked off before `Viewer` was constructed, so the `<img>` was being fetched without `crossorigin="anonymous"` and the resulting cross-origin-tainted texture threw `SecurityError: The operation is insecure` on `texImage2D`.
- Catch skybox load rejections in `index.ts` and log a warning instead of letting them propagate. Previously a skybox failure (CORS, 404, decode error) rejected `Promise.all([gsplatLoad, skyboxLoad, collisionLoad])` in `Viewer` and aborted the whole startup. Now the viewer comes up without an env map, matching the existing pattern used by the collision loaders.

Note: client-side `crossorigin="anonymous"` only resolves the WebGL tainting error if the skybox host also returns `Access-Control-Allow-Origin`. For hosts that don't, the image will now fail to load cleanly (and the viewer will keep going) instead of loading-but-tainting.

## Test plan
- [ ] Load a scene whose `skyboxUrl` is served with proper CORS headers — skybox renders, no `SecurityError`.
- [ ] Load a scene whose `skyboxUrl` is served without CORS headers — viewer continues, warning logged, gsplat still renders.
- [ ] Load a scene with no `skyboxUrl` — unchanged behavior.
- [ ] Load a scene with a 404 `skyboxUrl` — viewer continues, warning logged.