### PR TITLE
Forward pick events to the embedding page via postMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ By default the viewer uses WebGPU when available (falling back automatically whe
 | `fullload` | Load all streaming LOD data before the first frame |
 | `heatmap` | Render the heatmap debug overlay (WebGPU only) |
 
+## Embedding
+
+When the viewer runs inside an iframe, it posts a message to the embedding window each time the user picks a point on the scene (single click sets the orbit focus, double click picks a navigation target):
+
+```ts
+window.addEventListener('message', (e) => {
+    if (e.data?.type === 'pick') {
+        const { position, normal } = e.data; // [x, y, z] world-space arrays
+    }
+});
+```
+
 ## NPM Package
 
 The web app source files are available as strings for templating when you import the package from npm:

--- a/src/input/app/nav-interaction.ts
+++ b/src/input/app/nav-interaction.ts
@@ -151,7 +151,7 @@ class NavInteraction {
         if (target && request === this._targetPickRequest && this._global?.state.cameraMode === 'orbit') {
             const { events } = this._global;
             events.fire('orbitTarget:set', target.position, target.normal);
-            events.fire('pick', target.position);
+            events.fire('pick', target.position, target.normal);
         }
     }
 
@@ -250,7 +250,7 @@ class NavInteraction {
         if (currentMode === 'fly') {
             // 'pick' switches mode to orbit, which cancels the active fly nav
             // and would clobber any pre-set orbit target — set it after.
-            events.fire('pick', target.position);
+            events.fire('pick', target.position, target.normal);
             events.fire('orbitTarget:set', target.position, target.normal);
         } else if (currentMode === 'orbit' || currentMode === 'walk') {
             state.cameraMode = 'fly';

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -336,6 +336,18 @@ class Viewer {
             window.animationDuration = state.animationDuration;
         });
 
+        // forward scene picks (click sets focus, dblclick navigates) to the
+        // embedding page
+        if (window.parent !== window) {
+            events.on('pick', (position: Vec3, normal: Vec3) => {
+                window.parent.postMessage({
+                    type: 'pick',
+                    position: [position.x, position.y, position.z],
+                    normal: [normal.x, normal.y, normal.z]
+                }, '*');
+            });
+        }
+
         // wait for the model to load
         Promise.all([gsplatLoad, skyboxLoad, collisionLoad]).then((results) => {
             const gsplatComponent = results[0].gsplat as GSplatComponent;


### PR DESCRIPTION
Adds a small embedding API: when the viewer runs inside an iframe, it forwards the existing internal `pick` event to the parent window via `postMessage`, carrying the picked 3D surface point and estimated normal.

```js
window.addEventListener('message', (e) => {
    if (e.data?.type === 'pick') {
        const { position, normal } = e.data; // [x, y, z] world-space arrays
    }
});
```

### Motivation

The viewer already computes exactly this data on every click — `Picker.pickSurface()` resolves the alpha-weighted depth under the cursor and fits a surface normal, and `NavInteraction` fires `pick` to re-target the orbit camera. 

### Changes

- `NavInteraction`: `pick` now also carries `target.normal` (both fire sites already have it; the existing `CameraManager` listener is unaffected).
- `Viewer`: when `window.parent !== window`, forward `pick` to the parent as `{ type: 'pick', position: [x, y, z], normal: [x, y, z] }`, using the same `'*'` target origin as the existing fullscreen messages.
- `README`: short *Embedding* section documenting the message.

### Testing

- `npm run lint`, `npm run type:check`, `npm run build` all pass.
- Manually verified in Chrome: built viewer embedded in a same-origin iframe, loaded a Gaussian splat `.ply`, clicked the scene — parent received e.g. `{"type":"pick","position":[1.390,0.085,1.382],"normal":[0.137,0.973,0.185]}`, matching the clicked surface. Non-embedded (top-level) operation unchanged.

