### PR TITLE
Add opt-in debug engine build and migrate LOD range to GSplatComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ To initialize a local development environment for SuperSplat Viewer, ensure you 
 
 4. Open your browser at http://localhost:3000.
 
+### Debug engine build
+
+By default the viewer links against the release build of the PlayCanvas engine. Set `ENGINE=debug` to link against the engine's debug build instead, which includes runtime assertions and unminified, readable source for easier debugging:
+
+```sh
+ENGINE=debug npm run develop
+```
+
+This also works with `npm run build` and `npm run watch`.
+
 ## Settings Schema
 
 The `settings.json` file uses the schema below (defined in TypeScript and exported from `@playcanvas/supersplat-viewer/settings`). Legacy v1 settings produced by older SuperSplat releases are automatically migrated to v2 on load.

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -58,6 +58,8 @@ const buildCss = {
     ]
 };
 
+const debugEngine = process.env.ENGINE === 'debug';
+
 const buildPublic = {
     input: 'src/index.ts',
     output: {
@@ -66,7 +68,7 @@ const buildPublic = {
         sourcemap: true
     },
     plugins: [
-        resolve(),
+        resolve(debugEngine ? { exportConditions: ['development'] } : {}),
         typescript(),
         json(),
         htmlPlugin()

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -416,8 +416,8 @@ class Viewer {
                 };
 
                 gsplat.splatBudget = budget() * 1000000;
-                gsplat.lodRangeMin = 0;
-                gsplat.lodRangeMax = 1000;
+                gsplatComponent.lodRangeMin = 0;
+                gsplatComponent.lodRangeMax = 1000;
                 gsplat.colorUpdateAngle = state.performanceMode ? 4 : 2;
                 gsplat.minContribution = 1;
                 gsplat.alphaClip = 1 / 255;
@@ -432,7 +432,7 @@ class Viewer {
                 const resource = results[0].gsplat.resource as GSplatOctreeResourceLike | null;
                 const lodLevels = resource?.octree?.lodLevels;
                 if (lodLevels) {
-                    gsplat.lodRangeMax = gsplat.lodRangeMin = lodLevels - 1;
+                    gsplatComponent.lodRangeMax = gsplatComponent.lodRangeMin = lodLevels - 1;
                 }
             }
 


### PR DESCRIPTION
## Summary

Two small developer-facing changes:

- **Opt-in debug engine build.** Set `ENGINE=debug` to link the viewer against the
  PlayCanvas engine's debug build (runtime assertions, unminified/readable source)
  instead of the release build. Implemented via the `development` export condition in
  `@rollup/plugin-node-resolve`; default builds are unchanged.

- **Migrate LOD range to the per-component API.** Move `lodRangeMin` / `lodRangeMax`
  writes from the scene-level `app.scene.gsplat` (`GSplatParams`) onto the loaded
  `GSplatComponent`. Those `GSplatParams` setters are `@deprecated` in playcanvas 2.20.0
  and explicitly point to the component; this also scopes the LOD range to the specific
  splat rather than the global default.

## Usage

```sh
ENGINE=debug npm run develop   # also works with `npm run build` / `npm run watch`
```

## Testing

- `npm run type:check` passes.
- Verified release build links `build/playcanvas/...` and `ENGINE=debug` links
  `build/playcanvas.dbg/...`.