### PR TITLE
Add window.captureFrame for GPU-supersampled headless capture

### DIFF
--- a/src/capture.ts
+++ b/src/capture.ts
@@ -40,16 +40,16 @@ void main(void) {
         uv.y = 1.0 - uv.y;
     }
     vec2 base = floor(uv * outSize) * uRatio;
-    vec3 sum = vec3(0.0);
+    vec4 sum = vec4(0.0);
     for (int y = 0; y < 8; y++) {
         if (y >= r) break;
         for (int x = 0; x < 8; x++) {
             if (x >= r) break;
             vec2 texel = base + vec2(float(x) + 0.5, float(y) + 0.5);
-            sum += texture2D(source, texel / uSrcSize).rgb;
+            sum += texture2D(source, texel / uSrcSize);
         }
     }
-    gl_FragColor = vec4(sum / (uRatio * uRatio), 1.0);
+    gl_FragColor = sum / (uRatio * uRatio);
 }
 `;
 
@@ -73,16 +73,16 @@ fn fragmentMain(input: FragmentInput) -> FragmentOutput {
         uv.y = 1.0 - uv.y;
     }
     let base: vec2f = floor(uv * outSize) * uniform.uRatio;
-    var sum: vec3f = vec3f(0.0);
+    var sum: vec4f = vec4f(0.0);
     for (var y: i32 = 0; y < 8; y = y + 1) {
         if (y >= r) { break; }
         for (var x: i32 = 0; x < 8; x = x + 1) {
             if (x >= r) { break; }
             let texel: vec2f = base + vec2f(f32(x) + 0.5, f32(y) + 0.5);
-            sum = sum + textureSample(source, sourceSampler, texel / uniform.uSrcSize).rgb;
+            sum = sum + textureSample(source, sourceSampler, texel / uniform.uSrcSize);
         }
     }
-    output.color = vec4f(sum / (uniform.uRatio * uniform.uRatio), 1.0);
+    output.color = sum / (uniform.uRatio * uniform.uRatio);
     return output;
 }
 `;
@@ -183,8 +183,12 @@ class Capture {
         // clamp to the box shaders' 8x8 sample cap: a larger ratio would sum at most 64
         // texels yet still divide by ss*ss, producing an under-exposed (too dark) frame.
         const ss = Math.min(8, Math.max(1, Math.round(supersample)));
-        const srcW = width * ss;
-        const srcH = height * ss;
+        // normalize the output size to positive integers so texture/RT creation and
+        // readback don't fail confusingly on 0/negative/non-integer input
+        const outW = Math.max(1, Math.round(width));
+        const outH = Math.max(1, Math.round(height));
+        const srcW = outW * ss;
+        const srcH = outH * ss;
 
         // render the scene (incl. post effects) into our own supersampled target
         const srcRT = this.ensure('srcRT', srcW, srcH, true);
@@ -214,7 +218,7 @@ class Capture {
             });
 
             // box-downsample the supersampled render to the output size
-            const dstRT = this.ensure('dstRT', width, height, false);
+            const dstRT = this.ensure('dstRT', outW, outH, false);
             const { scope } = device;
             scope.resolve('source').setValue(srcRT.colorBuffer);
             scope.resolve('uSrcSize').setValue([srcW, srcH]);
@@ -223,14 +227,14 @@ class Capture {
             device.setBlendState(BlendState.NOBLEND);
             drawQuadWithShader(device, dstRT, this.shader);
 
-            const pixels = await dstRT.colorBuffer.read(0, 0, width, height, { renderTarget: dstRT, immediate: true });
+            const pixels = await dstRT.colorBuffer.read(0, 0, outW, outH, { renderTarget: dstRT, immediate: true });
             const u8 = pixels instanceof Uint8Array ? pixels : new Uint8Array(pixels.buffer);
             let binary = '';
             const chunk = 0x8000;
             for (let i = 0; i < u8.length; i += chunk) {
                 binary += String.fromCharCode.apply(null, u8.subarray(i, i + chunk) as unknown as number[]);
             }
-            return { width, height, data: btoa(binary) };
+            return { width: outW, height: outH, data: btoa(binary) };
         } finally {
             camera.aspectRatioMode = saved.aspectRatioMode;
             camera.aspectRatio = saved.aspectRatio;

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -1,0 +1,222 @@
+import {
+    ADDRESS_CLAMP_TO_EDGE,
+    ASPECT_AUTO,
+    BlendState,
+    drawQuadWithShader,
+    FILTER_LINEAR,
+    PIXELFORMAT_RGBA8,
+    RenderTarget,
+    SEMANTIC_POSITION,
+    ShaderUtils,
+    Texture
+} from 'playcanvas';
+import type { AppBase, CameraComponent, GraphicsDevice, Shader } from 'playcanvas';
+
+type CaptureFrame = { update(): void };
+
+// scrub advances the (paused) animation to `time` before the capture render
+type GrabOptions = { time?: number; width: number; height: number; supersample?: number; scrub?: (time: number) => void };
+
+type CaptureResult = { width: number; height: number; data: string };
+
+// Box-average downsample of a supersampled render. Each output texel averages the
+// `uRatio` x `uRatio` block of source texels it covers — true NxN supersampling, which
+// keeps thin high-frequency features (splat strings, edges) smooth, unlike a
+// bilinear/compositor downscale which aliases them. `uFlipY` flips vertically because
+// render targets and readback disagree on row order.
+const boxDownsampleGLSL = /* glsl */ `
+varying vec2 vUv0;
+
+uniform sampler2D source;
+uniform vec2 uSrcSize;
+uniform float uRatio;
+uniform float uFlipY;
+
+void main(void) {
+    int r = int(uRatio);
+    vec2 outSize = uSrcSize / uRatio;
+    vec2 uv = vUv0;
+    if (uFlipY > 0.5) {
+        uv.y = 1.0 - uv.y;
+    }
+    vec2 base = floor(uv * outSize) * uRatio;
+    vec3 sum = vec3(0.0);
+    for (int y = 0; y < 8; y++) {
+        if (y >= r) break;
+        for (int x = 0; x < 8; x++) {
+            if (x >= r) break;
+            vec2 texel = base + vec2(float(x) + 0.5, float(y) + 0.5);
+            sum += texture2D(source, texel / uSrcSize).rgb;
+        }
+    }
+    gl_FragColor = vec4(sum / (uRatio * uRatio), 1.0);
+}
+`;
+
+// WGSL twin of the box downsample (WebGPU can't compile GLSL, so a custom fullscreen
+// shader must supply WGSL too — the built-in fullscreenQuadVS chunk covers the vertex).
+const boxDownsampleWGSL = /* wgsl */ `
+varying vUv0: vec2f;
+var source: texture_2d<f32>;
+var sourceSampler: sampler;
+uniform uSrcSize: vec2f;
+uniform uRatio: f32;
+uniform uFlipY: f32;
+
+@fragment
+fn fragmentMain(input: FragmentInput) -> FragmentOutput {
+    var output: FragmentOutput;
+    let r: i32 = i32(uniform.uRatio);
+    let outSize: vec2f = uniform.uSrcSize / uniform.uRatio;
+    var uv: vec2f = input.vUv0;
+    if (uniform.uFlipY > 0.5) {
+        uv.y = 1.0 - uv.y;
+    }
+    let base: vec2f = floor(uv * outSize) * uniform.uRatio;
+    var sum: vec3f = vec3f(0.0);
+    for (var y: i32 = 0; y < 8; y = y + 1) {
+        if (y >= r) { break; }
+        for (var x: i32 = 0; x < 8; x = x + 1) {
+            if (x >= r) { break; }
+            let texel: vec2f = base + vec2f(f32(x) + 0.5, f32(y) + 0.5);
+            sum = sum + textureSample(source, sourceSampler, texel / uniform.uSrcSize).rgb;
+        }
+    }
+    output.color = vec4f(sum / (uniform.uRatio * uniform.uRatio), 1.0);
+    return output;
+}
+`;
+
+// Grabs downsampled snapshots of the viewer entirely on the GPU. The scene is rendered
+// (with post effects) into an app-owned render target at `supersample` x the requested
+// output size, box-downsampled to the output size, and only that small buffer is read
+// back. Rendering into our own target (rather than the backbuffer) means no
+// preserveDrawingBuffer, and it works on both WebGL and WebGPU.
+class Capture {
+    private app: AppBase;
+
+    private device: GraphicsDevice;
+
+    private camera: CameraComponent;
+
+    private getCameraFrame: () => CaptureFrame | null;
+
+    private shader: Shader;
+
+    private srcRT: RenderTarget | null = null;
+
+    private dstRT: RenderTarget | null = null;
+
+    constructor(
+        app: AppBase,
+        camera: CameraComponent,
+        getCameraFrame: () => CaptureFrame | null
+    ) {
+        this.app = app;
+        this.device = app.graphicsDevice;
+        this.camera = camera;
+        this.getCameraFrame = getCameraFrame;
+        this.shader = ShaderUtils.createShader(this.device, {
+            uniqueName: 'captureBoxDownsample',
+            attributes: { vertex_position: SEMANTIC_POSITION },
+            vertexChunk: 'fullscreenQuadVS',
+            fragmentGLSL: boxDownsampleGLSL,
+            fragmentWGSL: boxDownsampleWGSL
+        });
+    }
+
+    private makeRT(name: string, width: number, height: number, depth: boolean) {
+        // Plain RGBA8 (RGBA channel order, non-sRGB) so the box shader samples raw bytes
+        // and the readback returns raw RGBA — no channel swap (WebGPU backbuffers are
+        // often BGRA) and no sRGB decode/encode surprises; we average in the same gamma
+        // space sharp did. We only mirror the backbuffer's sRGB *flag* (which the viewer
+        // sets true only when post effects are active) — that drives the gamma the render
+        // pipeline writes with, so our target receives identical bytes to the screen.
+        const dev = this.device as { backBuffer?: { isColorBufferSrgb?: (i: number) => boolean } };
+        const srgb = dev.backBuffer?.isColorBufferSrgb?.(0) ?? false;
+        const colorBuffer = new Texture(this.device, {
+            name,
+            width,
+            height,
+            format: PIXELFORMAT_RGBA8,
+            mipmaps: false,
+            minFilter: FILTER_LINEAR,
+            magFilter: FILTER_LINEAR,
+            addressU: ADDRESS_CLAMP_TO_EDGE,
+            addressV: ADDRESS_CLAMP_TO_EDGE
+        });
+        const rt = new RenderTarget({ name, colorBuffer, depth });
+        (rt as { isColorBufferSrgb: () => boolean }).isColorBufferSrgb = () => srgb;
+        return rt;
+    }
+
+    private ensure(target: 'srcRT' | 'dstRT', width: number, height: number, depth: boolean) {
+        const existing = this[target];
+        if (existing && existing.width === width && existing.height === height) {
+            return existing;
+        }
+        existing?.colorBuffer.destroy();
+        existing?.destroy();
+        const rt = this.makeRT(target, width, height, depth);
+        this[target] = rt;
+        return rt;
+    }
+
+    async grab({ time, width, height, supersample = 2, scrub }: GrabOptions): Promise<CaptureResult> {
+        const device = this.device;
+        const ss = Math.max(1, Math.round(supersample));
+        const srcW = width * ss;
+        const srcH = height * ss;
+
+        // render the scene (incl. post effects) into our own supersampled target
+        const srcRT = this.ensure('srcRT', srcW, srcH, true);
+        if (this.camera.renderTarget !== srcRT) {
+            this.camera.renderTarget = srcRT;
+            this.camera.aspectRatioMode = ASPECT_AUTO; // aspect follows the target dims
+            this.camera.horizontalFov = srcW >= srcH;
+            // CameraFrame (post effects) binds its compose pass to the camera's render
+            // target inside setupRenderPasses, which update() only re-runs on a reset.
+            // A target change alone doesn't trigger that, so force it via layersDirty —
+            // otherwise the composited frame keeps going to the old target (backbuffer)
+            // and our RT reads back black.
+            const cameraFrame = this.getCameraFrame();
+            if (cameraFrame) {
+                const rpc = (cameraFrame as { renderPassCamera?: { layersDirty: boolean } }).renderPassCamera;
+                if (rpc) {
+                    rpc.layersDirty = true;
+                }
+                cameraFrame.update();
+            }
+        }
+
+        if (time !== undefined && scrub) {
+            scrub(time);
+        }
+        this.app.renderNextFrame = true;
+        await new Promise<void>((resolve) => {
+            this.app.once('frameend', () => resolve());
+        });
+
+        // box-downsample the supersampled render to the output size
+        const dstRT = this.ensure('dstRT', width, height, false);
+        const { scope } = device;
+        scope.resolve('source').setValue(srcRT.colorBuffer);
+        scope.resolve('uSrcSize').setValue([srcW, srcH]);
+        scope.resolve('uRatio').setValue(ss);
+        scope.resolve('uFlipY').setValue(srcRT.flipY ? 0 : 1);
+        device.setBlendState(BlendState.NOBLEND);
+        drawQuadWithShader(device, dstRT, this.shader);
+
+        const pixels = await dstRT.colorBuffer.read(0, 0, width, height, { renderTarget: dstRT, immediate: true });
+        const u8 = pixels instanceof Uint8Array ? pixels : new Uint8Array(pixels.buffer);
+        let binary = '';
+        const chunk = 0x8000;
+        for (let i = 0; i < u8.length; i += chunk) {
+            binary += String.fromCharCode.apply(null, u8.subarray(i, i + chunk) as unknown as number[]);
+        }
+        return { width, height, data: btoa(binary) };
+    }
+}
+
+export { Capture };
+export type { CaptureResult };

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -146,7 +146,7 @@ class Capture {
             addressV: ADDRESS_CLAMP_TO_EDGE
         });
         const rt = new RenderTarget({ name, colorBuffer, depth });
-        (rt as { isColorBufferSrgb: () => boolean }).isColorBufferSrgb = () => srgb;
+        (rt as { isColorBufferSrgb: (index: number) => boolean }).isColorBufferSrgb = () => srgb;
         return rt;
     }
 
@@ -229,12 +229,12 @@ class Capture {
 
             const pixels = await dstRT.colorBuffer.read(0, 0, outW, outH, { renderTarget: dstRT, immediate: true });
             const u8 = pixels instanceof Uint8Array ? pixels : new Uint8Array(pixels.buffer);
-            let binary = '';
+            const chunks: string[] = [];
             const chunk = 0x8000;
             for (let i = 0; i < u8.length; i += chunk) {
-                binary += String.fromCharCode.apply(null, u8.subarray(i, i + chunk) as unknown as number[]);
+                chunks.push(String.fromCharCode.apply(null, u8.subarray(i, i + chunk) as unknown as number[]));
             }
-            return { width: outW, height: outH, data: btoa(binary) };
+            return { width: outW, height: outH, data: btoa(chunks.join('')) };
         } finally {
             camera.aspectRatioMode = saved.aspectRatioMode;
             camera.aspectRatio = saved.aspectRatio;

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -162,59 +162,82 @@ class Capture {
         return rt;
     }
 
+    // Point the camera at `renderTarget` and re-target CameraFrame's compose pass. Post
+    // effects bind their output inside setupRenderPasses, which only re-runs on a reset,
+    // so a plain renderTarget change doesn't take effect — force a reset via layersDirty,
+    // otherwise the composited frame keeps going to the old target (reads back black).
+    private setCameraTarget(renderTarget: RenderTarget | null) {
+        this.camera.renderTarget = renderTarget;
+        const cameraFrame = this.getCameraFrame();
+        if (cameraFrame) {
+            const rpc = (cameraFrame as { renderPassCamera?: { layersDirty: boolean } }).renderPassCamera;
+            if (rpc) {
+                rpc.layersDirty = true;
+            }
+            cameraFrame.update();
+        }
+    }
+
     async grab({ time, width, height, supersample = 2, scrub }: GrabOptions): Promise<CaptureResult> {
         const device = this.device;
-        const ss = Math.max(1, Math.round(supersample));
+        // clamp to the box shaders' 8x8 sample cap: a larger ratio would sum at most 64
+        // texels yet still divide by ss*ss, producing an under-exposed (too dark) frame.
+        const ss = Math.min(8, Math.max(1, Math.round(supersample)));
         const srcW = width * ss;
         const srcH = height * ss;
 
         // render the scene (incl. post effects) into our own supersampled target
         const srcRT = this.ensure('srcRT', srcW, srcH, true);
-        if (this.camera.renderTarget !== srcRT) {
-            this.camera.renderTarget = srcRT;
-            this.camera.aspectRatioMode = ASPECT_AUTO; // aspect follows the target dims
-            this.camera.horizontalFov = srcW >= srcH;
-            // CameraFrame (post effects) binds its compose pass to the camera's render
-            // target inside setupRenderPasses, which update() only re-runs on a reset.
-            // A target change alone doesn't trigger that, so force it via layersDirty —
-            // otherwise the composited frame keeps going to the old target (backbuffer)
-            // and our RT reads back black.
-            const cameraFrame = this.getCameraFrame();
-            if (cameraFrame) {
-                const rpc = (cameraFrame as { renderPassCamera?: { layersDirty: boolean } }).renderPassCamera;
-                if (rpc) {
-                    rpc.layersDirty = true;
-                }
-                cameraFrame.update();
+
+        // Redirect the camera into our offscreen target for the capture, then restore it.
+        // window.captureFrame is a global API, so leaving the camera pointed at our target
+        // would freeze on-screen rendering after the first call.
+        const camera = this.camera;
+        const saved = {
+            renderTarget: camera.renderTarget,
+            aspectRatioMode: camera.aspectRatioMode,
+            aspectRatio: camera.aspectRatio,
+            horizontalFov: camera.horizontalFov
+        };
+
+        try {
+            camera.aspectRatioMode = ASPECT_AUTO; // aspect follows the target dims
+            camera.horizontalFov = srcW >= srcH;
+            this.setCameraTarget(srcRT);
+
+            if (time !== undefined && scrub) {
+                scrub(time);
             }
-        }
+            this.app.renderNextFrame = true;
+            await new Promise<void>((resolve) => {
+                this.app.once('frameend', () => resolve());
+            });
 
-        if (time !== undefined && scrub) {
-            scrub(time);
-        }
-        this.app.renderNextFrame = true;
-        await new Promise<void>((resolve) => {
-            this.app.once('frameend', () => resolve());
-        });
+            // box-downsample the supersampled render to the output size
+            const dstRT = this.ensure('dstRT', width, height, false);
+            const { scope } = device;
+            scope.resolve('source').setValue(srcRT.colorBuffer);
+            scope.resolve('uSrcSize').setValue([srcW, srcH]);
+            scope.resolve('uRatio').setValue(ss);
+            scope.resolve('uFlipY').setValue(srcRT.flipY ? 0 : 1);
+            device.setBlendState(BlendState.NOBLEND);
+            drawQuadWithShader(device, dstRT, this.shader);
 
-        // box-downsample the supersampled render to the output size
-        const dstRT = this.ensure('dstRT', width, height, false);
-        const { scope } = device;
-        scope.resolve('source').setValue(srcRT.colorBuffer);
-        scope.resolve('uSrcSize').setValue([srcW, srcH]);
-        scope.resolve('uRatio').setValue(ss);
-        scope.resolve('uFlipY').setValue(srcRT.flipY ? 0 : 1);
-        device.setBlendState(BlendState.NOBLEND);
-        drawQuadWithShader(device, dstRT, this.shader);
-
-        const pixels = await dstRT.colorBuffer.read(0, 0, width, height, { renderTarget: dstRT, immediate: true });
-        const u8 = pixels instanceof Uint8Array ? pixels : new Uint8Array(pixels.buffer);
-        let binary = '';
-        const chunk = 0x8000;
-        for (let i = 0; i < u8.length; i += chunk) {
-            binary += String.fromCharCode.apply(null, u8.subarray(i, i + chunk) as unknown as number[]);
+            const pixels = await dstRT.colorBuffer.read(0, 0, width, height, { renderTarget: dstRT, immediate: true });
+            const u8 = pixels instanceof Uint8Array ? pixels : new Uint8Array(pixels.buffer);
+            let binary = '';
+            const chunk = 0x8000;
+            for (let i = 0; i < u8.length; i += chunk) {
+                binary += String.fromCharCode.apply(null, u8.subarray(i, i + chunk) as unknown as number[]);
+            }
+            return { width, height, data: btoa(binary) };
+        } finally {
+            camera.aspectRatioMode = saved.aspectRatioMode;
+            camera.aspectRatio = saved.aspectRatio;
+            camera.horizontalFov = saved.horizontalFov;
+            this.setCameraTarget(saved.renderTarget);
+            this.app.renderNextFrame = true;
         }
-        return { width, height, data: btoa(binary) };
     }
 }
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -30,6 +30,7 @@ import {
 import { Annotations } from './annotations';
 import { CameraManager, isWalkAllowed } from './camera-manager';
 import { Camera } from './cameras/camera';
+import { Capture } from './capture';
 import type { Collision } from './collision';
 import { MeshCollision, VoxelCollision } from './collision';
 import { nearlyEquals } from './core/math';
@@ -328,6 +329,30 @@ class Viewer {
             };
 
             window.animationDuration = state.animationDuration;
+
+            // Capture hook for the thumbnail pipeline. Renders the scene (with post
+            // effects) into an offscreen supersampled target, GPU box-downsamples it to
+            // the requested size and returns just that small buffer. Lazily created on
+            // first use — no ?capture flag and no preserveDrawingBuffer needed, and it
+            // works on both WebGL and WebGPU.
+            let capture: Capture | null = null;
+            window.captureFrame = ({ time, width = 480, height = width, supersample } = {}) => {
+                if (!capture) {
+                    capture = new Capture(app, camera.camera, () => this.cameraFrame ?? null);
+                }
+                return capture.grab({
+                    time,
+                    width,
+                    height,
+                    supersample,
+                    scrub: (t) => {
+                        if (state.hasAnimation) {
+                            state.animationPaused = true;
+                            events.fire('scrubAnim', t);
+                        }
+                    }
+                });
+            };
         });
 
         // wait for the model to load

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -336,22 +336,30 @@ class Viewer {
             // first use — no ?capture flag and no preserveDrawingBuffer needed, and it
             // works on both WebGL and WebGPU.
             let capture: Capture | null = null;
+            let captureQueue: Promise<unknown> = Promise.resolve();
             window.captureFrame = ({ time, width = 480, height = width, supersample } = {}) => {
-                if (!capture) {
-                    capture = new Capture(app, camera.camera, () => this.cameraFrame ?? null);
-                }
-                return capture.grab({
-                    time,
-                    width,
-                    height,
-                    supersample,
-                    scrub: (t) => {
-                        if (state.hasAnimation) {
-                            state.animationPaused = true;
-                            events.fire('scrubAnim', t);
-                        }
+                const run = () => {
+                    if (!capture) {
+                        capture = new Capture(app, camera.camera, () => this.cameraFrame ?? null);
                     }
-                });
+                    return capture.grab({
+                        time,
+                        width,
+                        height,
+                        supersample,
+                        scrub: (t) => {
+                            if (state.hasAnimation) {
+                                state.animationPaused = true;
+                                events.fire('scrubAnim', t);
+                            }
+                        }
+                    });
+                };
+                // serialize calls: they share the viewer camera, so concurrent captures
+                // would interleave the redirect/restore and could leave it mis-targeted
+                const result = captureQueue.then(run, run);
+                captureQueue = result.then(() => {}, () => {});
+                return result;
             };
         });
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -12,6 +12,8 @@ interface Window {
 
     scrubTo?: (time: number) => Promise<void>;
 
+    captureFrame?: (options?: { time?: number; width?: number; height?: number; supersample?: number }) => Promise<{ width: number; height: number; data: string }>;
+
     animationDuration?: number;
 
     getCameraState?: () => {


### PR DESCRIPTION
## Summary

Adds `window.captureFrame()`, a headless capture API used by the backend thumbnail pipeline to grab still and animation frames. It renders the scene into an offscreen render target at a supersampled resolution, box-downsamples it to the requested size on the GPU, and returns only that small frame — replacing the pipeline's previous approach of CDP-screenshotting and PNG-encoding full-resolution frames (~1s/frame).

## API

`window.captureFrame(options?) => Promise<{ width, height, data }>`, where `data` is base64-encoded RGBA. Options: `time` scrubs the animation to that time before capturing (omit for the current pose), `width`/`height` set the output size (default 480, non-square supported), and `supersample` sets the render multiple (default 2).

## How it works

- Renders the camera — including post effects — into an app-owned `RenderTarget` at `supersample × output`, then a fullscreen box-average pass downsamples to the output size and only that small buffer is read back.
- Rendering into our own target instead of the backbuffer avoids `preserveDrawingBuffer` and works on both WebGL and WebGPU; the downsample shader is provided in both GLSL and WGSL.
- The box average is true NxN supersampling, so thin high-frequency features (e.g. splat "strings") stay smooth rather than aliasing.
- The capture target mirrors the backbuffer's sRGB treatment (which the viewer only forces under post effects) and re-targets the `CameraFrame` compose pass when redirecting the render target, so captured pixels match the on-screen render exactly across both the plain and post-effect paths.

## Notes

- Lazily constructed on first call and always available; no URL flag.
- Additive and isolated: no changes to rendering, sorting, LOD, renderer selection, or the interactive viewer path (3 files, +249/-0).