### PR TITLE
Apply work-buffer gsplat params before streaming starts

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -342,6 +342,9 @@ class Viewer {
 
             window.animationDuration = state.animationDuration;
 
+            // expose the app for console-driven debugging (e.g. scene.gsplat tuning)
+            window.app = app;
+
             // Capture hook for the thumbnail pipeline. Renders the scene (with post
             // effects) into an offscreen supersampled target, GPU box-downsamples it to
             // the requested size and returns just that small buffer. Lazily created on
@@ -462,12 +465,13 @@ class Viewer {
                 };
 
                 gsplat.splatBudget = budget() * 1000000;
+                gsplat.colorUpdateAngle = state.performanceMode ? 2 : 0;
                 gsplatComponent.lodRangeMin = 0;
                 gsplatComponent.lodRangeMax = 1000;
-                gsplat.colorUpdateAngle = state.performanceMode ? 4 : 2;
-                gsplat.minContribution = 1;
-                gsplat.alphaClip = 1 / 255;
-                gsplat.antiAlias = config.aa;
+
+                // request a frame so the param changes are processed (full work-buffer
+                // rebuild) even when on-demand rendering is active and the camera is idle
+                app.renderNextFrame = true;
             };
 
             if (config.fullload) {
@@ -485,9 +489,17 @@ class Viewer {
             // these two allow LOD behind camera to drop, saves lots of splats
             gsplat.lodUpdateAngle = 90;
             gsplat.lodBehindPenalty = 5;
+            gsplat.minContribution = 1;
+            gsplat.alphaClip = 1 / 255;
+            gsplat.antiAlias = config.aa;
 
             // same performance, but rotating on slow devices does not give us unsorted splats on sides
             gsplat.radialSorting = true;
+
+            // apply before streaming starts: this bakes into the work-buffer copies as
+            // persistent per-splat data, so the first loaded splats must already carry
+            // it (later changes only apply on a full rebuild)
+            gsplat.debug = config.colorize ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
 
             const eventHandler = app.systems.gsplat;
 
@@ -512,8 +524,6 @@ class Viewer {
                     events.on('performanceMode:changed', applyPerfSettings);
                     applyPerfSettings();
 
-                    // debug colorize lods
-                    gsplat.debug = config.colorize ? GSPLAT_DEBUG_LOD : GSPLAT_DEBUG_NONE;
                     gsplat.renderer = rendererTable[renderer];
 
                     // wait for the first valid frame to complete rendering

--- a/types.d.ts
+++ b/types.d.ts
@@ -10,6 +10,8 @@ interface Window {
 
     firstFrame?: () => void;
 
+    app?: import('playcanvas').AppBase;
+
     scrubTo?: (time: number) => Promise<void>;
 
     captureFrame?: (options?: { time?: number; width?: number; height?: number; supersample?: number }) => Promise<{ width: number; height: number; data: string }>;


### PR DESCRIPTION
## Summary

Several `scene.gsplat` params bake into the work buffer as persistent per-splat data, so they only take effect on a full rebuild. They were being set inside `applyPerfSettings`, which in the default (non-`fullload`) path doesn't run until the `frame:ready` handler fires — long after the first splats have streamed in. This moves those params to before streaming starts so the initial splats already carry them.

## Changes

- Move `minContribution`, `alphaClip` and `antiAlias` out of `applyPerfSettings` to the one-time setup block alongside `lodUpdateAngle` / `radialSorting`.
- Move `gsplat.debug` (the `?colorize` LOD visualization) out of the `frame:ready` handler for the same reason — previously the first-loaded splats were never colorized.
- Set `app.renderNextFrame = true` at the end of `applyPerfSettings`, so a performance-mode toggle is actually processed while on-demand rendering is active and the camera is idle.
- Retune `colorUpdateAngle` from `performanceMode ? 4 : 2` to `? 2 : 0`, tightening the color-update threshold in both modes.
- Expose the app instance as `window.app` for console-driven debugging, with a matching optional declaration in `types.d.ts`.

## Testing

`npm run lint`, `npm run type:check`, `npm run fmt` and `npm run build` all pass.