### PR TITLE
Fix loop-mode interpolation, end-of-playback behavior and double-click navigation

### DIFF
--- a/src/animation/anim-cursor.ts
+++ b/src/animation/anim-cursor.ts
@@ -43,8 +43,16 @@ class AnimCursor {
         this.cursor = 0;
     }
 
+    // true once a play-once animation has reached the end of the track
+    get ended() {
+        return this.loopMode === 'none' && this.cursor >= this.duration;
+    }
+
     set value(value: number) {
-        this.cursor = mod(value, this.duration);
+        // 'repeat' wraps (the end is the start); 'none' and 'pingpong' clamp so a
+        // scrub to the exact end parks on the last frame instead of wrapping to 0
+        this.cursor =
+            this.loopMode === 'repeat' ? mod(value, this.duration) : Math.max(0, Math.min(this.duration, value));
     }
 
     get value() {

--- a/src/animation/anim-state.ts
+++ b/src/animation/anim-state.ts
@@ -60,7 +60,12 @@ class AnimState {
 
         const extra = duration === times[times.length - 1] / frameRate ? 1 : 0;
 
-        const spline = CubicSpline.fromPointsLooping((duration + extra) * frameRate, times, points, smoothness);
+        // 'repeat' wraps the path from the last key back to the first; 'none' and
+        // 'pingpong' clamp at the outer keys, holding the end poses instead
+        const spline =
+            loopMode === 'repeat'
+                ? CubicSpline.fromPointsLooping((duration + extra) * frameRate, times, points, smoothness)
+                : CubicSpline.fromPoints(times, points, smoothness);
 
         return new AnimState(spline, duration, loopMode, frameRate);
     }

--- a/src/camera-manager.ts
+++ b/src/camera-manager.ts
@@ -179,6 +179,11 @@ class CameraManager {
             // update animation timeline
             if (state.cameraMode === 'anim') {
                 state.animationTime = controllers.anim.animState.cursor.value;
+
+                // a play-once animation pauses once it reaches the end of the track
+                if (!state.animationPaused && controllers.anim.animState.cursor.ended) {
+                    state.animationPaused = true;
+                }
             }
 
             if (clearOrbitTargetOnTransitionEnd && prevTransitionTimer < 1 && transitionTimer === 1) {
@@ -271,6 +276,18 @@ class CameraManager {
             // enter new controller
             const newController = getController(value);
             newController.onEnter(this.camera);
+        });
+
+        // pressing play at (or within a frame of) the end of a play-once animation
+        // restarts it from the beginning (a scrub can park just short of the end)
+        events.on('animationPaused:changed', (paused: boolean) => {
+            const animState = controllers.anim?.animState;
+            if (!paused && animState) {
+                const { cursor } = animState;
+                if (cursor.loopMode === 'none' && cursor.duration - cursor.value < 1 / animState.frameRate) {
+                    cursor.value = 0;
+                }
+            }
         });
 
         // handle user scrubbing the animation timeline

--- a/src/input/app/nav-interaction.ts
+++ b/src/input/app/nav-interaction.ts
@@ -240,24 +240,26 @@ class NavInteraction {
         if (eventName !== 'dblclick') return;
         if (!(event instanceof MouseEvent)) return;
         const { events, state } = global;
-        // dblclick swaps the active mode and uses the picked target:
-        //   fly          → orbit, focus orbit at point
-        //   orbit / walk → fly, navigate fly toward point
+        // dblclick in captured walk mode does nothing, like click
+        if (state.cameraMode === 'walk' && state.gamingControls) return;
+
         const request = ++this._targetPickRequest;
         const target = await this._pickSceneTarget(event.offsetX, event.offsetY);
         if (!target || request !== this._targetPickRequest) return;
 
-        const currentMode = this._global?.state.cameraMode;
-        if (currentMode === 'fly') {
-            // 'pick' switches mode to orbit, which cancels the active fly nav
-            // and would clobber any pre-set orbit target — set it after.
+        const currentState = this._global?.state;
+        if (!currentState) return;
+        if (currentState.cameraMode === 'walk') {
+            if (!currentState.gamingControls) {
+                // run to the picked point (same multiplier as shift-click)
+                events.fire('navigateTo', target.position, target.normal, 2);
+            }
+        } else {
+            // in other modes dblclick focuses orbit on the picked point.
+            // 'pick' switches mode to orbit, which cancels any active navigation
+            // and would clobber a pre-set orbit target — set it after.
             events.fire('pick', target.position);
             events.fire('orbitTarget:set', target.position, target.normal);
-        } else if (currentMode === 'orbit' || currentMode === 'walk') {
-            state.cameraMode = 'fly';
-            // Modifiers apply against the destination mode (fly), not the source.
-            const speedMul = computeClickSpeedMul(event, 'fly');
-            events.fire('navigateTo', target.position, target.normal, speedMul);
         }
     };
 
@@ -291,7 +293,7 @@ class NavInteraction {
         canvas.addEventListener('pointermove', this._onPointerMove);
         canvas.addEventListener('pointerup', this._onPointerUp);
 
-        // double-click/tap fallback -> fly target or orbit focus (skipped in walk mode)
+        // double-click/tap fallback -> run to walk target or orbit focus
         events.on('inputEvent', this._onInputEvent);
 
         // mobile tap (no movement) → walk/fly target or orbit focus

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -676,7 +676,7 @@ const initUI = (global: Global) => {
 
         const handleScrub = (event: PointerEvent) => {
             const rect = dom.timelineContainer.getBoundingClientRect();
-            const t = Math.max(0, Math.min(rect.width - 1, event.clientX - rect.left)) / rect.width;
+            const t = Math.max(0, Math.min(rect.width, event.clientX - rect.left)) / rect.width;
             events.fire('scrubAnim', state.animationDuration * t);
             showUI();
         };


### PR DESCRIPTION
Camera animation and navigation fixes:

- Spline interpolation now follows the track's `loopMode`: `repeat` wraps the path from the last key back to the first, while `none` and `pingpong` clamp at the outer keys and hold the end poses, matching the editor's non-looping timeline preview. Previously the viewer always built a looping spline, so play-once animations ended back at the first pose.
- Play-once (`none`) tracks now pause when they reach the end instead of sticking there in a playing state, and pressing play at (or within a frame of) the end restarts the animation from the beginning.
- The timeline scrubber can now reach the exact end of a track: the UI clamped one pixel short and an exact-end scrub wrapped the cursor back to 0, which made the first play press after scrubbing to the end appear to do nothing.
- Double-click now focuses orbit on the picked point from orbit and fly modes, runs to the picked point (2x, same as shift-click) in uncaptured walk mode, and does nothing in captured walk mode. It no longer toggles between orbit and fly.