### PR TITLE
Fix initial loading indication

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -342,14 +342,16 @@ const initUI = (global: Global) => {
     );
 
     // Handle loading progress updates
-    events.on('progress:changed', (progress) => {
+    const updateLoadingProgress = (progress: number) => {
         dom.loadingText.textContent = `${progress}%`;
         if (progress < 100) {
             dom.loadingBar.style.backgroundImage = `linear-gradient(90deg, #F60 0%, #F60 ${progress}%, white ${progress}%, white 100%)`;
         } else {
             dom.loadingBar.style.backgroundImage = 'linear-gradient(90deg, #F60 0%, #F60 100%)';
         }
-    });
+    };
+    events.on('progress:changed', updateLoadingProgress);
+    updateLoadingProgress(state.progress);
 
     // Hide loading bar once loaded
     events.on('loaded:changed', () => {


### PR DESCRIPTION
## Summary

- initialize the existing loading UI from the current progress state
- keep subsequent event-driven progress updates unchanged

Fixes #285.

## Verification

- delayed the scene response's first byte by 12 seconds: `main` remains blank, while this branch immediately shows `0%` and the progress bar
- automated headless regression check: `FAIL` on `main`, `PASS` on this branch
- Node 24 CI commands: type-check, build, 57 unit tests, publint, format, and lint all pass

## Visual evidence

The same scene and 12-second first-byte delay are used in both recordings.

**Before (`main` at `dcfc641`):** no loading indication is visible.

https://github.com/user-attachments/assets/1b18e9a1-1f0a-4f85-b80e-677ebb9c0efa

**After (`562bab0`):** `0%` and the loading bar are visible immediately.

https://github.com/user-attachments/assets/de983162-ebf2-4ee7-b2c7-d6781c6f0eeb
